### PR TITLE
BionicPRO: усиление безопасности SSO, сервис отчётов, кэширование чер…

### DIFF
--- a/airflow/dags/reports_etl_dag.py
+++ b/airflow/dags/reports_etl_dag.py
@@ -1,0 +1,107 @@
+"""Строит телеметрическую часть витрины отчётов по клиентам.
+
+Раньше этот DAG также при каждом запуске массово читал таблицу customers
+из CRM, что конкурировало с собственной OLTP-нагрузкой CRM. Теперь измерение
+с клиентами непрерывно поступает в ClickHouse через Debezium CDC (см. debezium/
+и clickhouse/init/02_cdc_mart.sql), поэтому этот DAG обращается только к базе
+телеметрии. reports.user_report_mart_v2_mv (ClickHouse) объединяет обе стороны
+при вставке.
+
+Параметры подключения к БД берутся из Airflow Variables (Admin -> Variables),
+а не хардкодятся в коде DAG. Значения по умолчанию соответствуют сервисам
+из docker-compose.yaml и используются, если переменная не задана. В этом
+стеке переменные заведены через переменные окружения контейнера airflow
+с префиксом AIRFLOW_VAR_* (см. docker-compose.yaml) - это официальный
+механизм Airflow, который не требует обращения к базе метаданных.
+"""
+from datetime import datetime
+
+import clickhouse_connect
+import psycopg2
+import psycopg2.extras
+from airflow import DAG
+from airflow.models import Variable
+from airflow.operators.python import PythonOperator
+
+
+def get_telemetry_dsn() -> dict:
+    # Variable.get() намеренно вызывается здесь, внутри функции задачи, а не
+    # на уровне модуля - обращение к Variables при разборе DAG на каждой
+    # итерации scheduler'а является анти-паттерном Airflow.
+    return {
+        "host": Variable.get("telemetry_db_host", default_var="telemetry_db"),
+        "port": int(Variable.get("telemetry_db_port", default_var="5432")),
+        "dbname": Variable.get("telemetry_db_name", default_var="telemetry"),
+        "user": Variable.get("telemetry_db_user", default_var="telemetry_user"),
+        "password": Variable.get("telemetry_db_password", default_var="telemetry_password"),
+    }
+
+
+def get_clickhouse_params() -> dict:
+    return {
+        "host": Variable.get("clickhouse_host", default_var="clickhouse"),
+        "username": Variable.get("clickhouse_user", default_var="reports"),
+        "password": Variable.get("clickhouse_password", default_var="reports_password"),
+    }
+
+
+def extract_telemetry_aggregates():
+    query = """
+        SELECT
+            customer_id,
+            count(*) AS events_count,
+            avg(myosignal_quality) AS avg_myosignal_quality,
+            avg(recognition_latency_ms) AS avg_recognition_latency_ms,
+            min(battery_level) AS min_battery_level,
+            (array_agg(action_recognized ORDER BY event_ts DESC))[1] AS last_action_recognized
+        FROM telemetry_events
+        GROUP BY customer_id
+    """
+    with psycopg2.connect(**get_telemetry_dsn()) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(query)
+            return cur.fetchall()
+
+
+def build_telemetry_agg(**_context):
+    aggregates = extract_telemetry_aggregates()
+    if not aggregates:
+        return
+
+    generated_at = datetime.utcnow()
+    rows = [
+        (
+            row["customer_id"],
+            generated_at,
+            int(row["events_count"]),
+            float(row["avg_myosignal_quality"]),
+            float(row["avg_recognition_latency_ms"]),
+            int(row["min_battery_level"]),
+            row["last_action_recognized"],
+        )
+        for row in aggregates
+    ]
+
+    client = clickhouse_connect.get_client(**get_clickhouse_params())
+    client.insert(
+        "reports.telemetry_agg",
+        rows,
+        column_names=[
+            "customer_id", "agg_generated_at", "events_count", "avg_myosignal_quality",
+            "avg_recognition_latency_ms", "min_battery_level", "last_action_recognized",
+        ],
+    )
+
+
+with DAG(
+    dag_id="reports_etl",
+    description="Aggregates prosthesis telemetry into the ClickHouse reporting mart",
+    schedule="0 * * * *",  # ежечасно
+    start_date=datetime(2026, 1, 1),
+    catchup=False,
+    tags=["bionicpro", "reports"],
+) as dag:
+    PythonOperator(
+        task_id="build_telemetry_agg",
+        python_callable=build_telemetry_agg,
+    )

--- a/architecture/task1-security-c4.drawio.xml
+++ b/architecture/task1-security-c4.drawio.xml
@@ -1,0 +1,135 @@
+<mxfile host="Electron" agent="bionicpro-architecture">
+  <diagram name="Task1-Security" id="task1-security-c4">
+    <mxGraphModel dx="1417" dy="759" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1700" pageHeight="800" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <object placeholders="1" c4Name="Пилот протеза / Пользователь" c4Type="Person" c4Description="Проходит SSO, скачивает отчёты" label="&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%]&lt;/div&gt;" id="n1">
+          <mxCell parent="1" style="html=1;fontSize=11;dashed=0;whiteSpace=wrap;fillColor=#6C6477;strokeColor=#4D4D4D;fontColor=#ffffff;shape=mxgraph.c4.person2;align=center;metaEdit=1;points=[[0.5,0,0],[1,0.5,0],[1,0.75,0],[0.75,1,0],[0.5,1,0],[0.25,1,0],[0,0.75,0],[0,0.5,0]];resizable=0;" vertex="1">
+            <mxGeometry height="110" width="180" x="40" y="260" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="Приложение донастройки / Web-отчёты" c4Type="Container" c4Technology="iOS, Android, React" c4Description="Инициирует вход через bionicpro-auth, хранит только сессионную cookie" label="&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;&lt;br&gt;&lt;div&gt;&lt;font style=&quot;font-size: 10px&quot;&gt;%c4Description%&lt;/font&gt;&lt;/div&gt;" id="n2">
+          <mxCell parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1061B0;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#0D5091;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="110" width="240" x="399.53" y="260" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="bionicpro-auth" c4Type="Container" c4Technology="Python, FastAPI" c4Description="PKCE-обмен с Keycloak, хранение access/refresh, ротация сессии, HttpOnly Secure cookie" label="&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;&lt;br&gt;&lt;div&gt;&lt;font style=&quot;font-size: 10px&quot;&gt;%c4Description%&lt;/font&gt;&lt;/div&gt;" id="n3">
+          <mxCell parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1061B0;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#0D5091;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="130" width="260" x="850" y="250" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="Session Store" c4Type="Container" c4Technology="Redis" c4Description="" label="&lt;font style=&quot;font-size: 13px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;" id="n4">
+          <mxCell parent="1" style="shape=cylinder3;size=15;whiteSpace=wrap;html=1;boundedLbl=1;rounded=0;fillColor=#23A2D9;fontSize=11;fontColor=#ffffff;align=center;strokeColor=#0E7DAD;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="90" width="220" x="419.53" y="450" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="Keycloak" c4Type="Container" c4Technology="Keycloak 26 (OIDC Provider)" c4Description="PKCE, refresh token TTL, OTP required action, Identity Brokering, LDAP User Federation" label="&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;&lt;br&gt;&lt;div&gt;&lt;font style=&quot;font-size: 10px&quot;&gt;%c4Description%&lt;/font&gt;&lt;/div&gt;" id="n5">
+          <mxCell parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0B5FA5;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#083E6E;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="140" width="260" x="1299.54" y="240" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="API отчётов" c4Type="Container" c4Technology="Spring Boot / FastAPI" c4Description="Bearer-only ресурс, проверяет JWT из bionicpro-auth" label="&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;&lt;br&gt;&lt;div&gt;&lt;font style=&quot;font-size: 10px&quot;&gt;%c4Description%&lt;/font&gt;&lt;/div&gt;" id="n6">
+          <mxCell parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1061B0;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#0D5091;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="110" width="260" x="850" y="600" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="LDAP представительства" c4Type="Container" c4Technology="OpenLDAP" c4Description="Источник учётных записей другой страны, персональные данные остаются локально" label="&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;&lt;br&gt;&lt;div&gt;&lt;font style=&quot;font-size: 10px&quot;&gt;%c4Description%&lt;/font&gt;&lt;/div&gt;" id="n7">
+          <mxCell parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#888888;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#5b5b5b;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="110" width="260" x="1299.54" y="20" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="Yandex ID" c4Type="Container" c4Technology="OAuth 2.0 IdP" c4Description="Внешний удостоверяющий сервис, брокеринг через Identity Provider" label="&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;&lt;br&gt;&lt;div&gt;&lt;font style=&quot;font-size: 10px&quot;&gt;%c4Description%&lt;/font&gt;&lt;/div&gt;" id="n8">
+          <mxCell parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#888888;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#5b5b5b;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="110" width="220" x="1774.79" y="255" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="CRM DB" c4Type="Container" c4Technology="PostgreSQL" c4Description="" label="&lt;font style=&quot;font-size: 13px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;" id="n9">
+          <mxCell parent="1" style="shape=cylinder3;size=15;whiteSpace=wrap;html=1;boundedLbl=1;rounded=0;fillColor=#23A2D9;fontSize=11;fontColor=#ffffff;align=center;strokeColor=#0E7DAD;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="90" width="220" x="1210" y="610" as="geometry" />
+          </mxCell>
+        </object>
+        <mxCell id="e10" edge="1" parent="1" source="n1" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;edgeStyle=orthogonalEdgeStyle;" target="n2">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e10l" connectable="0" parent="e10" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="Открывает приложение / веб" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint y="-7" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e11" edge="1" parent="1" source="n2" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;edgeStyle=orthogonalEdgeStyle;" target="n3">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="800" y="315" />
+              <mxPoint x="800" y="315" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e11l" connectable="0" parent="e11" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="GET /login, cookie bpro_session" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint x="-5" y="-7" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e12" edge="1" parent="1" source="n3" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;edgeStyle=orthogonalEdgeStyle;" target="n5">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1250" y="315" />
+              <mxPoint x="1250" y="315" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e12l" connectable="0" parent="e12" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="Authorization Code + PKCE&lt;br&gt;(code_verifier/code_challenge)" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e13" edge="1" parent="1" source="n3" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;edgeStyle=orthogonalEdgeStyle;" target="n4">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="890.03" y="480.03" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e13l" connectable="0" parent="e13" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="access/refresh token&lt;br&gt;(зашифрован)" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint x="-35" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e14" edge="1" parent="1" source="n5" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;" target="n7">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="1429.5399999999997" y="140" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e14l" connectable="0" parent="e14" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="User Federation&lt;br&gt;(поиск и bind пользователя)" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e15" edge="1" parent="1" source="n5" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;edgeStyle=orthogonalEdgeStyle;" target="n8">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e15l" connectable="0" parent="e15" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="Identity Brokering&lt;br&gt;(OAuth 2.0, generic IdP)" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e16" edge="1" parent="1" source="n3" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;edgeStyle=orthogonalEdgeStyle;" target="n6">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e16l" connectable="0" parent="e16" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="Bearer access_token&lt;br&gt;(proxy /api/*)" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e17" edge="1" parent="1" source="n6" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="n9">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e17l" connectable="0" parent="e17" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="SQL" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/architecture/task2-reports-c4.drawio.xml
+++ b/architecture/task2-reports-c4.drawio.xml
@@ -1,0 +1,127 @@
+<mxfile host="Electron" agent="bionicpro-architecture">
+  <diagram name="Task2-Reports" id="task2-reports-c4">
+    <mxGraphModel dx="1956" dy="1048" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1400" pageHeight="800" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <object placeholders="1" c4Name="Пилот протеза / Пользователь" c4Type="Person" c4Description="Скачивает отчёт о работе своего протеза" label="&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%]&lt;/div&gt;" id="m1">
+          <mxCell parent="1" style="html=1;fontSize=11;dashed=0;whiteSpace=wrap;fillColor=#6C6477;strokeColor=#4D4D4D;fontColor=#ffffff;shape=mxgraph.c4.person2;align=center;metaEdit=1;points=[[0.5,0,0],[1,0.5,0],[1,0.75,0],[0.75,1,0],[0.5,1,0],[0.25,1,0],[0,0.75,0],[0,0.5,0]];resizable=0;" vertex="1">
+            <mxGeometry height="110" width="170" x="15" y="185" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="Web-отчёты" c4Type="Container" c4Technology="React" c4Description="Кнопка Download Report, только сессионная cookie" label="&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;&lt;br&gt;&lt;div&gt;&lt;font style=&quot;font-size: 10px&quot;&gt;%c4Description%&lt;/font&gt;&lt;/div&gt;" id="m2">
+          <mxCell parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1061B0;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#0D5091;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="110" width="220" x="375" y="185" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="bionicpro-auth" c4Type="Container" c4Technology="Python, FastAPI" c4Description="Проксирует /api/reports с access_token" label="&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;&lt;br&gt;&lt;div&gt;&lt;font style=&quot;font-size: 10px&quot;&gt;%c4Description%&lt;/font&gt;&lt;/div&gt;" id="m3">
+          <mxCell parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1061B0;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#0D5091;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="110" width="220" x="755" y="180" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="reports-api" c4Type="Container" c4Technology="Python, FastAPI" c4Description="Bearer-only, отдаёт готовый отчёт только по своему customer_id из JWT, без вычислений на лету" label="&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;&lt;br&gt;&lt;div&gt;&lt;font style=&quot;font-size: 10px&quot;&gt;%c4Description%&lt;/font&gt;&lt;/div&gt;" id="m4">
+          <mxCell parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1061B0;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#0D5091;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="120" width="260" x="1125" y="170" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="reports.user_report_mart" c4Type="Container" c4Technology="ClickHouse (OLAP)" c4Description="" label="&lt;font style=&quot;font-size: 13px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;" id="m5">
+          <mxCell parent="1" style="shape=cylinder3;size=15;whiteSpace=wrap;html=1;boundedLbl=1;rounded=0;fillColor=#23A2D9;fontSize=11;fontColor=#ffffff;align=center;strokeColor=#0E7DAD;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="100" width="260" x="1125" y="375" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="Airflow DAG reports_etl" c4Type="Container" c4Technology="Apache Airflow" c4Description="Почасовой ETL: извлекает CRM + телеметрию, строит витрину" label="&lt;font style=&quot;font-size: 14px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;&lt;br&gt;&lt;div&gt;&lt;font style=&quot;font-size: 10px&quot;&gt;%c4Description%&lt;/font&gt;&lt;/div&gt;" id="m6">
+          <mxCell parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0B5FA5;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#083E6E;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="120" width="250" x="645" y="365" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="CRM DB" c4Type="Container" c4Technology="PostgreSQL (Oracle в проде)" c4Description="" label="&lt;font style=&quot;font-size: 13px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;" id="m7">
+          <mxCell parent="1" style="shape=cylinder3;size=15;whiteSpace=wrap;html=1;boundedLbl=1;rounded=0;fillColor=#23A2D9;fontSize=11;fontColor=#ffffff;align=center;strokeColor=#0E7DAD;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="100" width="220" x="255" y="365" as="geometry" />
+          </mxCell>
+        </object>
+        <object placeholders="1" c4Name="Telemetry DB" c4Type="Container" c4Technology="PostgreSQL" c4Description="" label="&lt;font style=&quot;font-size: 13px&quot;&gt;&lt;b&gt;%c4Name%&lt;/b&gt;&lt;/font&gt;&lt;div&gt;[%c4Type%: %c4Technology%]&lt;/div&gt;" id="m8">
+          <mxCell parent="1" style="shape=cylinder3;size=15;whiteSpace=wrap;html=1;boundedLbl=1;rounded=0;fillColor=#23A2D9;fontSize=11;fontColor=#ffffff;align=center;strokeColor=#0E7DAD;metaEdit=1;resizable=0;" vertex="1">
+            <mxGeometry height="100" width="220" x="255" y="515" as="geometry" />
+          </mxCell>
+        </object>
+        <mxCell id="me9" edge="1" parent="1" source="m1" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="m2">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="me9l" connectable="0" parent="me9" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="Открывает веб-приложение" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint x="5" y="-7" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="me10" edge="1" parent="1" source="m2" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;edgeStyle=orthogonalEdgeStyle;" target="m3">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="715" y="240" />
+              <mxPoint x="715" y="240" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="me10l" connectable="0" parent="me10" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="GET /api/reports + cookie" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint y="-7" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="me11" edge="1" parent="1" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;edgeStyle=orthogonalEdgeStyle;">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1085" y="234.75" />
+              <mxPoint x="1085" y="234.75" />
+            </Array>
+            <mxPoint x="975" y="234.75" as="sourcePoint" />
+            <mxPoint x="1125" y="234.75" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="me11l" connectable="0" parent="me11" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="Bearer access_token" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint y="-5" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="me12" edge="1" parent="1" source="m4" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;edgeStyle=orthogonalEdgeStyle;" target="m5">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="me12l" connectable="0" parent="me12" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="SELECT последняя строка по customer_id" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="me13" edge="1" parent="1" source="m6" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;edgeStyle=orthogonalEdgeStyle;" target="m7">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="605" y="415" />
+              <mxPoint x="605" y="415" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="me13l" connectable="0" parent="me13" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="extract customers" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="me14" edge="1" parent="1" source="m6" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;edgeStyle=orthogonalEdgeStyle;" target="m8">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="770.05" y="575" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="me14l" connectable="0" parent="me14" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="extract telemetry" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="me15" edge="1" parent="1" source="m6" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;edgeStyle=orthogonalEdgeStyle;" target="m5">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="me15l" connectable="0" parent="me15" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=10;" value="load агрегаты (почасово)" vertex="1">
+          <mxGeometry relative="1" y="-2" as="geometry">
+            <mxPoint y="-2" as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/bionicpro-auth/Dockerfile
+++ b/bionicpro-auth/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+EXPOSE 4000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "4000"]

--- a/bionicpro-auth/app/config.py
+++ b/bionicpro-auth/app/config.py
@@ -1,0 +1,46 @@
+import os
+
+
+class Settings:
+    keycloak_internal_url: str = os.environ.get("KEYCLOAK_INTERNAL_URL", "http://keycloak:8080")
+    keycloak_public_url: str = os.environ.get("KEYCLOAK_PUBLIC_URL", "http://localhost:8080")
+    keycloak_realm: str = os.environ.get("KEYCLOAK_REALM", "reports-realm")
+    keycloak_client_id: str = os.environ.get("KEYCLOAK_CLIENT_ID", "reports-frontend")
+
+    redis_url: str = os.environ.get("REDIS_URL", "redis://redis:6379/0")
+
+    session_cookie_name: str = os.environ.get("SESSION_COOKIE_NAME", "bpro_session")
+    session_ttl_seconds: int = int(os.environ.get("SESSION_TTL_SECONDS", "1800"))
+    # Обновляем access_token немного раньше фактического истечения срока действия, чтобы избежать гонки.
+    access_token_refresh_margin_seconds: int = int(os.environ.get("ACCESS_TOKEN_REFRESH_MARGIN_SECONDS", "10"))
+
+    frontend_url: str = os.environ.get("FRONTEND_URL", "http://localhost:3000")
+    auth_service_base_url: str = os.environ.get("AUTH_SERVICE_BASE_URL", "http://localhost:4000")
+    reports_api_url: str = os.environ.get("REPORTS_API_URL", "http://reports-api:8000")
+
+    # Симметричный ключ для шифрования refresh_token при хранении в Redis (Fernet, 32 url-safe base64 байта).
+    # Задано фиксированное значение по умолчанию для локальной разработки, чтобы стек запускался из коробки; в реальном окружении обязательно переопределить.
+    token_encryption_key: str = os.environ.get(
+        "TOKEN_ENCRYPTION_KEY", "Z2xpvVqLhq3s6E4b8m5f1nQxWc0aRt7uYd9pKj2Ns8I="
+    )
+
+    cookie_secure: bool = os.environ.get("COOKIE_SECURE", "true").lower() == "true"
+
+    @property
+    def authorization_endpoint(self) -> str:
+        return f"{self.keycloak_public_url}/realms/{self.keycloak_realm}/protocol/openid-connect/auth"
+
+    @property
+    def token_endpoint(self) -> str:
+        return f"{self.keycloak_internal_url}/realms/{self.keycloak_realm}/protocol/openid-connect/token"
+
+    @property
+    def logout_endpoint(self) -> str:
+        return f"{self.keycloak_internal_url}/realms/{self.keycloak_realm}/protocol/openid-connect/logout"
+
+    @property
+    def redirect_uri(self) -> str:
+        return f"{self.auth_service_base_url}/callback"
+
+
+settings = Settings()

--- a/bionicpro-auth/app/jwt_utils.py
+++ b/bionicpro-auth/app/jwt_utils.py
@@ -1,0 +1,16 @@
+import base64
+import json
+
+
+def decode_claims_unverified(jwt_token: str) -> dict:
+    """Декодирует payload JWT без проверки подписи.
+
+    Токен читается здесь исключительно сразу после того, как он был выдан нам
+    напрямую token endpoint по доверенному серверному вызову, поэтому проверка
+    подписи не требуется для доверия его содержимому. reports-api, который
+    получает токен от недоверенного вызывающего, обязан проверять его отдельно.
+    """
+    payload_segment = jwt_token.split(".")[1]
+    padding = "=" * (-len(payload_segment) % 4)
+    decoded = base64.urlsafe_b64decode(payload_segment + padding)
+    return json.loads(decoded)

--- a/bionicpro-auth/app/keycloak_client.py
+++ b/bionicpro-auth/app/keycloak_client.py
@@ -1,0 +1,65 @@
+import time
+from typing import Optional
+from urllib.parse import urlencode
+
+import httpx
+
+from .config import settings
+
+
+class TokenResponse:
+    def __init__(self, payload: dict):
+        self.access_token: str = payload["access_token"]
+        self.refresh_token: str = payload["refresh_token"]
+        self.access_expires_at: float = time.time() + int(payload["expires_in"])
+        self.refresh_expires_at: float = time.time() + int(payload["refresh_expires_in"])
+        self.sub: Optional[str] = None
+        self.preferred_username: Optional[str] = None
+
+
+def build_authorization_url(state: str, code_challenge: str) -> str:
+    params = {
+        "client_id": settings.keycloak_client_id,
+        "response_type": "code",
+        "scope": "openid",
+        "redirect_uri": settings.redirect_uri,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    return f"{settings.authorization_endpoint}?{urlencode(params)}"
+
+
+async def exchange_code_for_tokens(code: str, code_verifier: str) -> TokenResponse:
+    data = {
+        "grant_type": "authorization_code",
+        "client_id": settings.keycloak_client_id,
+        "code": code,
+        "redirect_uri": settings.redirect_uri,
+        "code_verifier": code_verifier,
+    }
+    async with httpx.AsyncClient() as client:
+        response = await client.post(settings.token_endpoint, data=data)
+        response.raise_for_status()
+        return TokenResponse(response.json())
+
+
+async def refresh_tokens(refresh_token: str) -> TokenResponse:
+    data = {
+        "grant_type": "refresh_token",
+        "client_id": settings.keycloak_client_id,
+        "refresh_token": refresh_token,
+    }
+    async with httpx.AsyncClient() as client:
+        response = await client.post(settings.token_endpoint, data=data)
+        response.raise_for_status()
+        return TokenResponse(response.json())
+
+
+async def revoke_refresh_token(refresh_token: str) -> None:
+    data = {
+        "client_id": settings.keycloak_client_id,
+        "refresh_token": refresh_token,
+    }
+    async with httpx.AsyncClient() as client:
+        await client.post(settings.logout_endpoint, data=data)

--- a/bionicpro-auth/app/main.py
+++ b/bionicpro-auth/app/main.py
@@ -1,0 +1,197 @@
+import httpx
+from fastapi import FastAPI, Request, Response, HTTPException
+from fastapi.responses import RedirectResponse
+from starlette.middleware.cors import CORSMiddleware
+
+from . import keycloak_client, pkce
+from .config import settings
+from .jwt_utils import decode_claims_unverified
+from .session_store import (
+    SessionData,
+    create_session,
+    delete_session,
+    encrypt_refresh_token,
+    decrypt_refresh_token,
+    get_session,
+    now,
+    pop_pkce_verifier,
+    store_pkce_verifier,
+)
+
+app = FastAPI(title="bionicpro-auth")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[settings.frontend_url],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+def _set_session_cookie(response: Response, session_id: str) -> None:
+    response.set_cookie(
+        key=settings.session_cookie_name,
+        value=session_id,
+        httponly=True,
+        secure=settings.cookie_secure,
+        samesite="lax",
+        max_age=settings.session_ttl_seconds,
+        path="/",
+    )
+
+
+def _clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(key=settings.session_cookie_name, path="/")
+
+
+async def _persist_tokens(token_response: keycloak_client.TokenResponse) -> str:
+    claims = decode_claims_unverified(token_response.access_token)
+    data = SessionData(
+        sub=claims.get("sub", ""),
+        username=claims.get("preferred_username", ""),
+        access_token=token_response.access_token,
+        access_expires_at=token_response.access_expires_at,
+        refresh_token_encrypted=encrypt_refresh_token(token_response.refresh_token),
+        refresh_expires_at=token_response.refresh_expires_at,
+    )
+    session_id = pkce.generate_session_id()
+    await create_session(session_id, data)
+    return session_id
+
+
+async def require_valid_session(request: Request, response: Response) -> SessionData:
+    """Проверяет сессионную cookie, при необходимости обновляет access_token
+    и перепривязывает сессию к новому session id при каждой успешной проверке
+    защищённого ресурса (предотвращает session fixation attack).
+    """
+    session_id = request.cookies.get(settings.session_cookie_name)
+    if not session_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    data = await get_session(session_id)
+    if data is None:
+        raise HTTPException(status_code=401, detail="Session expired or unknown")
+
+    if now() >= data.access_expires_at - settings.access_token_refresh_margin_seconds:
+        refresh_token = decrypt_refresh_token(data.refresh_token_encrypted)
+        try:
+            token_response = await keycloak_client.refresh_tokens(refresh_token)
+        except httpx.HTTPStatusError:
+            await delete_session(session_id)
+            raise HTTPException(status_code=401, detail="Session could not be refreshed")
+        claims = decode_claims_unverified(token_response.access_token)
+        data = SessionData(
+            sub=claims.get("sub", ""),
+            username=claims.get("preferred_username", ""),
+            access_token=token_response.access_token,
+            access_expires_at=token_response.access_expires_at,
+            refresh_token_encrypted=encrypt_refresh_token(token_response.refresh_token),
+            refresh_expires_at=token_response.refresh_expires_at,
+        )
+
+    new_session_id = pkce.generate_session_id()
+    await create_session(new_session_id, data)
+    await delete_session(session_id)
+    _set_session_cookie(response, new_session_id)
+
+    return data
+
+
+@app.get("/login")
+async def login():
+    state = pkce.generate_state()
+    code_verifier = pkce.generate_code_verifier()
+    code_challenge = pkce.derive_code_challenge(code_verifier)
+    await store_pkce_verifier(state, code_verifier)
+    return RedirectResponse(keycloak_client.build_authorization_url(state, code_challenge))
+
+
+@app.get("/callback")
+async def callback(request: Request):
+    error = request.query_params.get("error")
+    if error:
+        raise HTTPException(status_code=400, detail=f"Identity provider error: {error}")
+
+    code = request.query_params.get("code")
+    state = request.query_params.get("state")
+    if not code or not state:
+        raise HTTPException(status_code=400, detail="Missing code or state")
+
+    code_verifier = await pop_pkce_verifier(state)
+    if not code_verifier:
+        raise HTTPException(status_code=400, detail="Unknown or expired state")
+
+    token_response = await keycloak_client.exchange_code_for_tokens(code, code_verifier)
+    session_id = await _persist_tokens(token_response)
+
+    redirect = RedirectResponse(settings.frontend_url)
+    _set_session_cookie(redirect, session_id)
+    return redirect
+
+
+@app.get("/me")
+async def me(request: Request, response: Response):
+    # Возврат обычного dict (а не нового JSONResponse) позволяет FastAPI
+    # слить заголовки/cookie, которые require_valid_session выставил на
+    # внедрённый объект `response`, в фактически отправляемый ответ.
+    data = await require_valid_session(request, response)
+    return {"sub": data.sub, "username": data.username}
+
+
+@app.post("/logout")
+async def logout(request: Request, response: Response):
+    session_id = request.cookies.get(settings.session_cookie_name)
+    if session_id:
+        data = await get_session(session_id)
+        if data:
+            await keycloak_client.revoke_refresh_token(decrypt_refresh_token(data.refresh_token_encrypted))
+        await delete_session(session_id)
+    _clear_session_cookie(response)
+    return {"status": "logged_out"}
+
+
+_HOP_BY_HOP_HEADERS = {
+    "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+    "te", "trailers", "transfer-encoding", "upgrade", "host", "cookie",
+}
+
+
+@app.api_route("/api/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+async def proxy_to_reports_api(path: str, request: Request, response: Response):
+    """Backend-for-frontend прокси: браузер никогда не видит access_token,
+    он лишь предъявляет сессионную cookie. Этот эндпоинт подставляет
+    хранящийся на сервере access_token перед проксированием вызова в reports-api.
+    """
+    data = await require_valid_session(request, response)
+
+    body = await request.body()
+    forward_headers = {
+        k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP_HEADERS
+    }
+    forward_headers["Authorization"] = f"Bearer {data.access_token}"
+
+    async with httpx.AsyncClient() as client:
+        upstream = await client.request(
+            method=request.method,
+            url=f"{settings.reports_api_url}/{path}",
+            params=request.query_params,
+            content=body,
+            headers=forward_headers,
+            timeout=30.0,
+        )
+
+    proxied = Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        media_type=upstream.headers.get("content-type"),
+    )
+    rotated_cookie = response.headers.get("set-cookie")
+    if rotated_cookie:
+        proxied.headers["set-cookie"] = rotated_cookie
+    return proxied
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/bionicpro-auth/app/pkce.py
+++ b/bionicpro-auth/app/pkce.py
@@ -1,0 +1,20 @@
+import base64
+import hashlib
+import secrets
+
+
+def generate_code_verifier() -> str:
+    return base64.urlsafe_b64encode(secrets.token_bytes(64)).rstrip(b"=").decode("ascii")
+
+
+def derive_code_challenge(code_verifier: str) -> str:
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def generate_state() -> str:
+    return secrets.token_urlsafe(24)
+
+
+def generate_session_id() -> str:
+    return secrets.token_urlsafe(32)

--- a/bionicpro-auth/app/session_store.py
+++ b/bionicpro-auth/app/session_store.py
@@ -1,0 +1,72 @@
+import json
+import time
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+import redis.asyncio as redis
+from cryptography.fernet import Fernet
+
+from .config import settings
+
+_redis = redis.from_url(settings.redis_url, decode_responses=True)
+_fernet = Fernet(settings.token_encryption_key.encode("ascii"))
+
+_PKCE_PREFIX = "bpro:pkce:"
+_SESSION_PREFIX = "bpro:session:"
+_PKCE_TTL_SECONDS = 300
+
+
+@dataclass
+class SessionData:
+    sub: str
+    username: str
+    access_token: str
+    access_expires_at: float
+    refresh_token_encrypted: str
+    refresh_expires_at: float
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self))
+
+    @staticmethod
+    def from_json(raw: str) -> "SessionData":
+        return SessionData(**json.loads(raw))
+
+
+def encrypt_refresh_token(refresh_token: str) -> str:
+    return _fernet.encrypt(refresh_token.encode("utf-8")).decode("ascii")
+
+
+def decrypt_refresh_token(token_encrypted: str) -> str:
+    return _fernet.decrypt(token_encrypted.encode("ascii")).decode("utf-8")
+
+
+async def store_pkce_verifier(state: str, code_verifier: str) -> None:
+    await _redis.set(_PKCE_PREFIX + state, code_verifier, ex=_PKCE_TTL_SECONDS)
+
+
+async def pop_pkce_verifier(state: str) -> Optional[str]:
+    key = _PKCE_PREFIX + state
+    value = await _redis.get(key)
+    if value is not None:
+        await _redis.delete(key)
+    return value
+
+
+async def create_session(session_id: str, data: SessionData) -> None:
+    await _redis.set(_SESSION_PREFIX + session_id, data.to_json(), ex=settings.session_ttl_seconds)
+
+
+async def get_session(session_id: str) -> Optional[SessionData]:
+    raw = await _redis.get(_SESSION_PREFIX + session_id)
+    if raw is None:
+        return None
+    return SessionData.from_json(raw)
+
+
+async def delete_session(session_id: str) -> None:
+    await _redis.delete(_SESSION_PREFIX + session_id)
+
+
+def now() -> float:
+    return time.time()

--- a/bionicpro-auth/requirements.txt
+++ b/bionicpro-auth/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+httpx==0.27.2
+redis==5.0.8
+cryptography==43.0.1
+python-multipart==0.0.9

--- a/clickhouse/init/01_schema.sql
+++ b/clickhouse/init/01_schema.sql
@@ -1,0 +1,20 @@
+CREATE DATABASE IF NOT EXISTS reports;
+
+-- Витрина отчётов: одна строка на клиента на каждый обработанный пакет ETL.
+-- Наполняется исключительно Airflow DAG (airflow/dags/reports_etl_dag.py) -
+-- слой API только читает из этой таблицы, никогда не вычисляет агрегаты на лету.
+CREATE TABLE IF NOT EXISTS reports.user_report_mart
+(
+    customer_id             String,
+    report_generated_at     DateTime,
+    full_name               String,
+    region                  String,
+    prosthesis_model        String,
+    events_count            UInt32,
+    avg_myosignal_quality   Float32,
+    avg_recognition_latency_ms Float32,
+    min_battery_level       UInt8,
+    last_action_recognized  String
+)
+ENGINE = ReplacingMergeTree(report_generated_at)
+ORDER BY (customer_id);

--- a/clickhouse/init/02_cdc_mart.sql
+++ b/clickhouse/init/02_cdc_mart.sql
@@ -1,0 +1,86 @@
+-- Путь приёма CDC: Debezium стримит изменения строк из crm.public.customers
+-- в топик Kafka 'crm.public.customers'; ClickHouse потребляет его напрямую
+-- через движок Kafka, поэтому Airflow больше вообще не выполняет массовое
+-- чтение OLTP-базы CRM.
+CREATE TABLE IF NOT EXISTS reports.customers_cdc_kafka
+(
+    customer_id       String,
+    full_name         String,
+    region            String,
+    prosthesis_model  String
+)
+ENGINE = Kafka
+SETTINGS
+    kafka_broker_list = 'kafka:9092',
+    kafka_topic_list = 'crm.public.customers',
+    kafka_group_name = 'clickhouse_reports_consumer',
+    kafka_format = 'JSONEachRow',
+    kafka_num_consumers = 1,
+    kafka_skip_broken_messages = 5;
+
+CREATE TABLE IF NOT EXISTS reports.customers_current
+(
+    customer_id       String,
+    full_name         String,
+    region            String,
+    prosthesis_model  String,
+    updated_at        DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY customer_id;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS reports.customers_current_mv
+TO reports.customers_current AS
+SELECT customer_id, full_name, region, prosthesis_model, now() AS updated_at
+FROM reports.customers_cdc_kafka;
+
+-- Агрегаты телеметрии по-прежнему формируются пакетно через Airflow DAG
+-- (airflow/dags/reports_etl_dag.py), который теперь обращается только к базе
+-- телеметрии - никогда к базе CRM.
+CREATE TABLE IF NOT EXISTS reports.telemetry_agg
+(
+    customer_id                 String,
+    agg_generated_at            DateTime,
+    events_count                UInt32,
+    avg_myosignal_quality       Float32,
+    avg_recognition_latency_ms  Float32,
+    min_battery_level           UInt8,
+    last_action_recognized      String
+)
+ENGINE = MergeTree
+ORDER BY (customer_id, agg_generated_at);
+
+-- Итоговая витрина отчётов: объединяет измерение клиентов, поступающее через
+-- CDC, с пакетными агрегатами телеметрии через MaterializedView, срабатывающую
+-- на каждую вставку Airflow в telemetry_agg. reports-api читает только эту таблицу.
+CREATE TABLE IF NOT EXISTS reports.user_report_mart_v2
+(
+    customer_id                 String,
+    report_generated_at         DateTime,
+    full_name                   String,
+    region                      String,
+    prosthesis_model            String,
+    events_count                UInt32,
+    avg_myosignal_quality       Float32,
+    avg_recognition_latency_ms  Float32,
+    min_battery_level           UInt8,
+    last_action_recognized      String
+)
+ENGINE = ReplacingMergeTree(report_generated_at)
+ORDER BY (customer_id);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS reports.user_report_mart_v2_mv
+TO reports.user_report_mart_v2 AS
+SELECT
+    t.customer_id AS customer_id,
+    t.agg_generated_at AS report_generated_at,
+    c.full_name AS full_name,
+    c.region AS region,
+    c.prosthesis_model AS prosthesis_model,
+    t.events_count AS events_count,
+    t.avg_myosignal_quality AS avg_myosignal_quality,
+    t.avg_recognition_latency_ms AS avg_recognition_latency_ms,
+    t.min_battery_level AS min_battery_level,
+    t.last_action_recognized AS last_action_recognized
+FROM reports.telemetry_agg AS t
+LEFT JOIN reports.customers_current AS c FINAL ON c.customer_id = t.customer_id;

--- a/crm/init/01_schema.sql
+++ b/crm/init/01_schema.sql
@@ -1,0 +1,19 @@
+-- Замена CRM DB Битрикс24 (в проде - Oracle) для локальной разработки.
+-- Хранит записи о клиентах, с которыми ETL отчётности объединяет
+-- телеметрию протезов.
+CREATE TABLE customers (
+    customer_id   VARCHAR(64) PRIMARY KEY,   -- совпадает с именем пользователя в Keycloak
+    full_name     VARCHAR(255) NOT NULL,
+    region        VARCHAR(128) NOT NULL,
+    prosthesis_model VARCHAR(128) NOT NULL,
+    signup_date   DATE NOT NULL
+);
+
+INSERT INTO customers (customer_id, full_name, region, prosthesis_model, signup_date) VALUES
+    ('user1', 'User One', 'Moscow', 'BionicPRO Hand X1', '2025-01-15'),
+    ('user2', 'User Two', 'Saint Petersburg', 'BionicPRO Hand X1', '2025-02-20'),
+    ('prothetic1', 'Prothetic One', 'Kazan', 'BionicPRO Hand X2', '2025-03-05'),
+    ('prothetic2', 'Prothetic Two', 'Novosibirsk', 'BionicPRO Leg L1', '2025-03-18'),
+    ('prothetic3', 'Prothetic Three', 'Yekaterinburg', 'BionicPRO Hand X2', '2025-04-02'),
+    ('john.doe', 'John Doe', 'Berlin (representative office)', 'BionicPRO Hand X1', '2025-05-10'),
+    ('jane.smith', 'Jane Smith', 'Berlin (representative office)', 'BionicPRO Leg L1', '2025-05-22');

--- a/debezium/crm-customers-connector.json
+++ b/debezium/crm-customers-connector.json
@@ -1,0 +1,23 @@
+{
+  "name": "crm-customers-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.hostname": "crm_db",
+    "database.port": "5432",
+    "database.user": "crm_user",
+    "database.password": "crm_password",
+    "database.dbname": "crm",
+    "topic.prefix": "crm",
+    "table.include.list": "public.customers",
+    "plugin.name": "pgoutput",
+    "slot.name": "debezium_crm_slot",
+    "publication.autocreate.mode": "filtered",
+    "transforms": "unwrap",
+    "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
+    "transforms.unwrap.drop.tombstones": "false",
+    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "key.converter.schemas.enable": "false",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false"
+  }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   keycloak_db:
     image: postgres:14
@@ -11,8 +9,30 @@ services:
       - ./postgres-keycloak-data:/var/lib/postgresql/data
     ports:
       - "5433:5432"
+
+  openldap:
+    image: osixia/openldap:1.5.0
+    container_name: openldap
+    command: --copy-service
+    volumes:
+      - ./ldap/config.ldif:/container/service/slapd/assets/config/bootstrap/ldif/50-bootstrap.ldif
+    environment:
+      - LDAP_ORGANISATION=example-com
+      - LDAP_DOMAIN=example.com
+      - LDAP_ADMIN_PASSWORD=admin
+    ports:
+      - "389:389"
+      - "636:636"
+
+  redis:
+    image: redis:7-alpine
+    container_name: bionicpro-redis
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    ports:
+      - "6379:6379"
+
   keycloak:
-    image: quay.io/keycloak/keycloak:21.1
+    image: quay.io/keycloak/keycloak:26.3
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
@@ -20,23 +40,217 @@ services:
       KC_DB_URL: jdbc:postgresql://keycloak_db:5432/keycloak_db
       KC_DB_USERNAME: keycloak_user
       KC_DB_PASSWORD: keycloak_password
-    command: 
+      KC_HOSTNAME: localhost
+      KC_HOSTNAME_STRICT: "false"
+      KC_HTTP_ENABLED: "true"
+      KC_PROXY_HEADERS: xforwarded
+      KC_HTTPS_CERTIFICATE_FILE: /opt/keycloak/certs/server.crt.pem
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /opt/keycloak/certs/server.key.pem
+    command:
       - start-dev
       - --import-realm
     volumes:
       - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json
+      - ./keycloak/certs:/opt/keycloak/certs:ro
     ports:
       - "8080:8080"
+      - "8443:8443"
     depends_on:
       - keycloak_db
+      - openldap
+
+  bionicpro-auth:
+    build:
+      context: ./bionicpro-auth
+      dockerfile: Dockerfile
+    container_name: bionicpro-auth
+    environment:
+      KEYCLOAK_INTERNAL_URL: http://keycloak:8080
+      KEYCLOAK_PUBLIC_URL: https://localhost:8443
+      KEYCLOAK_REALM: reports-realm
+      KEYCLOAK_CLIENT_ID: reports-frontend
+      REDIS_URL: redis://redis:6379/0
+      SESSION_COOKIE_NAME: bpro_session
+      SESSION_TTL_SECONDS: "1800"
+      FRONTEND_URL: http://localhost:3000
+      AUTH_SERVICE_BASE_URL: http://localhost:4000
+      REPORTS_API_URL: http://reports-api:8000
+      COOKIE_SECURE: "false"
+    ports:
+      - "4000:4000"
+    depends_on:
+      - keycloak
+      - redis
+
   frontend:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        REACT_APP_AUTH_URL: http://localhost:4000
     ports:
       - "3000:3000"
+    depends_on:
+      - bionicpro-auth
+
+  crm_db:
+    image: postgres:14
+    container_name: crm_db
+    command: ["postgres", "-c", "wal_level=logical"]
     environment:
-      REACT_APP_API_URL: http://localhost:8000
-      REACT_APP_KEYCLOAK_URL: http://localhost:8080
-      REACT_APP_KEYCLOAK_REALM: reports-realm
-      REACT_APP_KEYCLOAK_CLIENT_ID: reports-frontend
+      POSTGRES_DB: crm
+      POSTGRES_USER: crm_user
+      POSTGRES_PASSWORD: crm_password
+    volumes:
+      - ./crm/init:/docker-entrypoint-initdb.d:ro
+    ports:
+      - "5434:5432"
+
+  telemetry_db:
+    image: postgres:14
+    container_name: telemetry_db
+    environment:
+      POSTGRES_DB: telemetry
+      POSTGRES_USER: telemetry_user
+      POSTGRES_PASSWORD: telemetry_password
+    volumes:
+      - ./telemetry/init:/docker-entrypoint-initdb.d:ro
+    ports:
+      - "5435:5432"
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.8
+    container_name: clickhouse
+    environment:
+      CLICKHOUSE_USER: reports
+      CLICKHOUSE_PASSWORD: reports_password
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+    volumes:
+      - ./clickhouse/init:/docker-entrypoint-initdb.d:ro
+    ports:
+      - "8123:8123"
+      - "9009:9000"
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+
+  airflow:
+    image: apache/airflow:2.10.2-python3.11
+    container_name: airflow
+    user: "50000:0"
+    command: standalone
+    environment:
+      AIRFLOW__CORE__EXECUTOR: SequentialExecutor
+      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: sqlite:////opt/airflow/airflow.db
+      AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+      AIRFLOW__CORE__DAGS_FOLDER: /opt/airflow/dags
+      _PIP_ADDITIONAL_REQUIREMENTS: "psycopg2-binary==2.9.9 clickhouse-connect==0.8.3"
+      AIRFLOW_VAR_TELEMETRY_DB_HOST: telemetry_db
+      AIRFLOW_VAR_TELEMETRY_DB_PORT: "5432"
+      AIRFLOW_VAR_TELEMETRY_DB_NAME: telemetry
+      AIRFLOW_VAR_TELEMETRY_DB_USER: telemetry_user
+      AIRFLOW_VAR_TELEMETRY_DB_PASSWORD: telemetry_password
+      AIRFLOW_VAR_CLICKHOUSE_HOST: clickhouse
+      AIRFLOW_VAR_CLICKHOUSE_USER: reports
+      AIRFLOW_VAR_CLICKHOUSE_PASSWORD: reports_password
+    volumes:
+      - ./airflow/dags:/opt/airflow/dags
+      - airflow_data:/opt/airflow
+    ports:
+      - "8081:8080"
+    depends_on:
+      - crm_db
+      - telemetry_db
+      - clickhouse
+
+  reports-api:
+    build:
+      context: ./reports-api
+      dockerfile: Dockerfile
+    container_name: reports-api
+    environment:
+      KEYCLOAK_INTERNAL_URL: http://keycloak:8080
+      KEYCLOAK_REALM: reports-realm
+      EXPECTED_AUDIENCE: reports-api
+      EXPECTED_ISSUER: https://localhost:8443/realms/reports-realm
+      CLICKHOUSE_HOST: clickhouse
+      CLICKHOUSE_PORT: "8123"
+      CLICKHOUSE_USER: reports
+      CLICKHOUSE_PASSWORD: reports_password
+      S3_ENDPOINT_URL: http://minio:9000
+      S3_ACCESS_KEY: minio_user
+      S3_SECRET_KEY: minio_password
+      S3_BUCKET: reports
+      CDN_BASE_URL: http://localhost:8090
+      REPORT_LINK_SECRET: dev-report-link-secret-change-in-production
+      REDIS_URL: redis://redis:6379/1
+      POINTER_CACHE_TTL_SECONDS: "300"
+    depends_on:
+      - keycloak
+      - clickhouse
+      - minio
+      - redis
+
+  minio:
+    image: minio/minio
+    container_name: minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_storage:/data
+    environment:
+      MINIO_ROOT_USER: minio_user
+      MINIO_ROOT_PASSWORD: minio_password
+    command: server --console-address ":9001" /data
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: bionicpro-cdn
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - nginx_cache:/var/cache/nginx
+    ports:
+      - "8090:8080"
+    depends_on:
+      - minio
+
+  zookeeper:
+    image: quay.io/debezium/zookeeper:2.7
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: quay.io/debezium/kafka:2.7
+    container_name: kafka
+    environment:
+      ZOOKEEPER_CONNECT: zookeeper:2181
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+
+  kafka-connect:
+    image: quay.io/debezium/connect:2.7
+    container_name: kafka-connect
+    environment:
+      BOOTSTRAP_SERVERS: kafka:9092
+      GROUP_ID: bionicpro-connect
+      CONFIG_STORAGE_TOPIC: bionicpro_connect_configs
+      OFFSET_STORAGE_TOPIC: bionicpro_connect_offsets
+      STATUS_STORAGE_TOPIC: bionicpro_connect_statuses
+      CONFIG_STORAGE_REPLICATION_FACTOR: "1"
+      OFFSET_STORAGE_REPLICATION_FACTOR: "1"
+      STATUS_STORAGE_REPLICATION_FACTOR: "1"
+    ports:
+      - "8083:8083"
+    depends_on:
+      - kafka
+      - crm_db
+
+volumes:
+  airflow_data: {}
+  minio_storage: {}
+  nginx_cache: {}

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,4 +1,1 @@
-REACT_APP_API_URL=http://localhost:8000
-REACT_APP_KEYCLOAK_URL=http://localhost:8080
-REACT_APP_KEYCLOAK_REALM=reports-realm
-REACT_APP_KEYCLOAK_CLIENT_ID=reports-frontend
+REACT_APP_AUTH_URL=http://localhost:4000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,31 +1,36 @@
-# Build stage
+# Стадия сборки
 FROM node:16-alpine as build
 
 WORKDIR /app
 
-# Copy package files
+# Копируем файлы пакета
 COPY package.json package-lock.json ./
 
-# Install dependencies
+# Устанавливаем зависимости
 RUN npm ci
 
-# Copy source code
+# Копируем исходный код
 COPY . .
 
-# Build the app
+# Переменные REACT_APP_* вшиваются в статический бандл на этапе сборки,
+# поэтому их нужно передавать как build args, а не как env-переменные контейнера.
+ARG REACT_APP_AUTH_URL
+ENV REACT_APP_AUTH_URL=$REACT_APP_AUTH_URL
+
+# Собираем приложение
 RUN npm run build
 
-# Production stage
+# Продакшн-стадия
 FROM nginx:alpine
 
-# Copy built assets from build stage
+# Копируем собранные файлы со стадии сборки
 COPY --from=build /app/build /usr/share/nginx/html
 
-# Copy nginx configuration
+# Копируем конфигурацию nginx
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-# Expose port
+# Открываем порт
 EXPOSE 3000
 
-# Start nginx
+# Запускаем nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,9 @@
             "name": "reports-frontend",
             "version": "0.1.0",
             "dependencies": {
-                "@react-keycloak/web": "^3.4.0",
                 "@types/node": "^16.18.0",
                 "@types/react": "^18.0.0",
                 "@types/react-dom": "^18.0.0",
-                "keycloak-js": "^21.1.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-scripts": "5.0.1",
@@ -2911,46 +2909,6 @@
                 }
             }
         },
-        "node_modules/@react-keycloak/core": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@react-keycloak/core/-/core-3.2.0.tgz",
-            "integrity": "sha512-1yzU7gQzs+6E1v6hGqxy0Q+kpMHg9sEcke2yxZR29WoU8KNE8E50xS6UbI8N7rWsgyYw8r9W1cUPCOF48MYjzw==",
-            "dependencies": {
-                "react-fast-compare": "^3.2.0"
-            },
-            "funding": {
-                "type": "patreon",
-                "url": "https://www.patreon.com/reactkeycloak"
-            },
-            "peerDependencies": {
-                "react": ">=16"
-            }
-        },
-        "node_modules/@react-keycloak/web": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/@react-keycloak/web/-/web-3.4.0.tgz",
-            "integrity": "sha512-yKKSCyqBtn7dt+VckYOW1IM5NW999pPkxDZOXqJ6dfXPXstYhOQCkTZqh8l7UL14PkpsoaHDh7hSJH8whah01g==",
-            "dependencies": {
-                "@babel/runtime": "^7.9.0",
-                "@react-keycloak/core": "^3.2.0",
-                "hoist-non-react-statics": "^3.3.2"
-            },
-            "funding": {
-                "type": "patreon",
-                "url": "https://www.patreon.com/reactkeycloak"
-            },
-            "peerDependencies": {
-                "keycloak-js": ">=9.0.2",
-                "react": ">=16.8",
-                "react-dom": ">=16.8",
-                "typescript": ">=3.8"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@rollup/plugin-babel": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -4729,25 +4687,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-        },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
         },
         "node_modules/batch": {
             "version": "0.6.1",
@@ -8041,14 +7980,6 @@
                 "he": "bin/he"
             }
         },
-        "node_modules/hoist-non-react-statics": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-            "dependencies": {
-                "react-is": "^16.7.0"
-            }
-        },
         "node_modules/hoopy": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -9880,11 +9811,6 @@
                 "jiti": "bin/jiti.js"
             }
         },
-        "node_modules/js-sha256": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10047,15 +9973,6 @@
             },
             "engines": {
                 "node": ">=4.0"
-            }
-        },
-        "node_modules/keycloak-js": {
-            "version": "21.1.2",
-            "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-21.1.2.tgz",
-            "integrity": "sha512-+6r1BvmutWGJBtibo7bcFbHWIlA7XoXRCwcA4vopeJh59Nv2Js0ju2u+t8AYth+C6Cg7/BNfO3eCTbsl/dTBHw==",
-            "dependencies": {
-                "base64-js": "^1.5.1",
-                "js-sha256": "^0.9.0"
             }
         },
         "node_modules/keyv": {
@@ -12659,11 +12576,6 @@
             "version": "6.0.11",
             "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
             "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
-        },
-        "node_modules/react-fast-compare": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-            "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
         },
         "node_modules/react-is": {
             "version": "16.13.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,11 +3,9 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-      "@react-keycloak/web": "^3.4.0",
       "@types/node": "^16.18.0",
       "@types/react": "^18.0.0",
       "@types/react-dom": "^18.0.0",
-      "keycloak-js": "^21.1.0",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",
       "react-scripts": "5.0.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,23 +1,14 @@
 import React from 'react';
-import { ReactKeycloakProvider } from '@react-keycloak/web';
-import Keycloak, { KeycloakConfig } from 'keycloak-js';
+import { AuthProvider } from './auth/AuthContext';
 import ReportPage from './components/ReportPage';
-
-const keycloakConfig: KeycloakConfig = {
-  url: process.env.REACT_APP_KEYCLOAK_URL,
-  realm: process.env.REACT_APP_KEYCLOAK_REALM||"",
-  clientId: process.env.REACT_APP_KEYCLOAK_CLIENT_ID||""
-};
-
-const keycloak = new Keycloak(keycloakConfig);
 
 const App: React.FC = () => {
   return (
-    <ReactKeycloakProvider authClient={keycloak}>
+    <AuthProvider>
       <div className="App">
         <ReportPage />
       </div>
-    </ReactKeycloakProvider>
+    </AuthProvider>
   );
 };
 

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const AUTH_URL = process.env.REACT_APP_AUTH_URL || 'http://localhost:4000';
+
+interface AuthState {
+  loading: boolean;
+  authenticated: boolean;
+  username: string | null;
+  login: () => void;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [loading, setLoading] = useState(true);
+  const [authenticated, setAuthenticated] = useState(false);
+  const [username, setUsername] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${AUTH_URL}/me`, { credentials: 'include' })
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error('not authenticated');
+        }
+        return res.json();
+      })
+      .then((data) => {
+        setAuthenticated(true);
+        setUsername(data.username);
+      })
+      .catch(() => {
+        setAuthenticated(false);
+        setUsername(null);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Аутентификация - это полная навигация страницы: bionicpro-auth
+  // перенаправляет браузер через Keycloak и обратно. Фронтенд никогда
+  // не обращается к Keycloak напрямую и не работает с токенами.
+  const login = () => {
+    window.location.href = `${AUTH_URL}/login`;
+  };
+
+  const logout = async () => {
+    await fetch(`${AUTH_URL}/logout`, { method: 'POST', credentials: 'include' });
+    setAuthenticated(false);
+    setUsername(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ loading, authenticated, username, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return ctx;
+}
+
+export { AUTH_URL };

--- a/frontend/src/components/ReportPage.tsx
+++ b/frontend/src/components/ReportPage.tsx
@@ -1,44 +1,56 @@
 import React, { useState } from 'react';
-import { useKeycloak } from '@react-keycloak/web';
+import { useAuth, AUTH_URL } from '../auth/AuthContext';
 
 const ReportPage: React.FC = () => {
-  const { keycloak, initialized } = useKeycloak();
-  const [loading, setLoading] = useState(false);
+  const { loading, authenticated, username, login, logout } = useAuth();
+  const [reportLoading, setReportLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [reportUrl, setReportUrl] = useState<string | null>(null);
 
   const downloadReport = async () => {
-    if (!keycloak?.token) {
-      setError('Not authenticated');
-      return;
-    }
-
     try {
-      setLoading(true);
+      setReportLoading(true);
       setError(null);
+      setReportUrl(null);
 
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/reports`, {
-        headers: {
-          'Authorization': `Bearer ${keycloak.token}`
-        }
+      // Браузер хранит только cookie bpro_session. bionicpro-auth
+      // подставляет access_token на сервере перед проксированием этого вызова.
+      const response = await fetch(`${AUTH_URL}/api/reports`, {
+        credentials: 'include',
       });
 
-      
+      if (response.status === 404) {
+        throw new Error('No report has been generated for this period yet');
+      }
+      if (!response.ok) {
+        throw new Error(`Report request failed: ${response.status}`);
+      }
+
+      const data = await response.json();
+      // reports-api отдаёт ссылку на объектное хранилище/CDN, когда она
+      // доступна (Задание 3); до этого возвращает тело отчёта напрямую.
+      if (data.url) {
+        setReportUrl(data.url);
+      } else {
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        setReportUrl(URL.createObjectURL(blob));
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
-      setLoading(false);
+      setReportLoading(false);
     }
   };
 
-  if (!initialized) {
+  if (loading) {
     return <div>Loading...</div>;
   }
 
-  if (!keycloak.authenticated) {
+  if (!authenticated) {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
         <button
-          onClick={() => keycloak.login()}
+          onClick={login}
           className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
         >
           Login
@@ -50,17 +62,30 @@ const ReportPage: React.FC = () => {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
       <div className="p-8 bg-white rounded-lg shadow-md">
-        <h1 className="text-2xl font-bold mb-6">Usage Reports</h1>
-        
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl font-bold">Usage Reports</h1>
+          <button onClick={logout} className="ml-6 text-sm text-gray-500 hover:underline">
+            Logout ({username})
+          </button>
+        </div>
+
         <button
           onClick={downloadReport}
-          disabled={loading}
+          disabled={reportLoading}
           className={`px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 ${
-            loading ? 'opacity-50 cursor-not-allowed' : ''
+            reportLoading ? 'opacity-50 cursor-not-allowed' : ''
           }`}
         >
-          {loading ? 'Generating Report...' : 'Download Report'}
+          {reportLoading ? 'Generating Report...' : 'Download Report'}
         </button>
+
+        {reportUrl && (
+          <div className="mt-4">
+            <a href={reportUrl} target="_blank" rel="noreferrer" className="text-blue-600 underline">
+              Open report
+            </a>
+          </div>
+        )}
 
         {error && (
           <div className="mt-4 p-4 bg-red-100 text-red-700 rounded">

--- a/keycloak/certs/generate.sh
+++ b/keycloak/certs/generate.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Генерирует самоподписанный TLS-сертификат для локального HTTPS-листенера
+# Keycloak (порт 8443). Последние версии Keycloak всегда помечают cookie
+# сессии аутентификации как Secure; SameSite=None, поэтому браузерному
+# эндпоинту нужен настоящий (пусть и самоподписанный) TLS-листенер, чтобы
+# вход работал через localhost. Запустите один раз перед `docker compose up`.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+openssl req -x509 -newkey rsa:2048 -keyout server.key.pem -out server.crt.pem \
+  -days 3650 -nodes -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+echo "Generated keycloak/certs/server.crt.pem and server.key.pem"

--- a/keycloak/keycloak-results-export.json
+++ b/keycloak/keycloak-results-export.json
@@ -1,0 +1,2420 @@
+{
+  "id" : "95c0e286-4ae1-45ae-a251-21fc4a91d135",
+  "realm" : "reports-realm",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : true,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 120,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxTemporaryLockouts" : 0,
+  "bruteForceStrategy" : "MULTIPLE",
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "e5bf9608-0fc4-4cd1-8694-0c5bbf74cc6a",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "95c0e286-4ae1-45ae-a251-21fc4a91d135",
+      "attributes" : { }
+    }, {
+      "id" : "0b1f5c0d-472b-4847-837a-5426620c5728",
+      "name" : "administrator",
+      "description" : "Administrator role",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "95c0e286-4ae1-45ae-a251-21fc4a91d135",
+      "attributes" : { }
+    }, {
+      "id" : "2f2f05f6-431f-4199-8983-b29d56f41497",
+      "name" : "user",
+      "description" : "Regular user role",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "95c0e286-4ae1-45ae-a251-21fc4a91d135",
+      "attributes" : { }
+    }, {
+      "id" : "b52c6a83-542b-44f4-8791-55256374f1f4",
+      "name" : "default-roles-reports-realm",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "manage-account", "view-profile" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "95c0e286-4ae1-45ae-a251-21fc4a91d135",
+      "attributes" : { }
+    }, {
+      "id" : "d2cbf85f-52b9-4732-964a-f243ea49f3ed",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "95c0e286-4ae1-45ae-a251-21fc4a91d135",
+      "attributes" : { }
+    }, {
+      "id" : "6e63ba03-38ae-46da-a3ce-6af0ec2a015b",
+      "name" : "prothetic_user",
+      "description" : "Prothetic user role with report access",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "95c0e286-4ae1-45ae-a251-21fc4a91d135",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "realm-management" : [ {
+        "id" : "a99d225b-dac9-414b-a302-33ad2178c797",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-users", "query-groups" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "47daaf16-38ee-4390-b959-1fd895f87d0e",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "a13f88b1-bf46-451b-b087-3efb54d77ad8",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "26aee9f6-0c66-41f0-afe3-f27794545783",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "9dc168c7-c65a-404a-9385-95a9a36a9a92",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "baada984-8b13-4f48-9066-2bc9f13a4927",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "e8865511-27c0-402c-b041-e916ff3828d1",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "view-users", "manage-clients", "manage-identity-providers", "manage-authorization", "manage-events", "query-users", "manage-realm", "view-realm", "view-identity-providers", "manage-users", "query-realms", "view-clients", "view-events", "create-client", "view-authorization", "impersonation", "query-clients", "query-groups" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "1d3d4ae6-4351-485a-885b-fb6456c8f05d",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "59612a22-1b29-41e4-b723-4f03ffe9d4aa",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "e45e72af-b3c4-4ef4-8f1b-d6ac60dcef89",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "2eca218a-cca8-498a-b4e7-b3f7eb02538c",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "fd46dde8-5517-48ba-b629-0c6a1ad3b603",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "4f2379c1-3a3e-457b-8e94-fa9f0e6c9937",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "d2dbbd41-6345-4618-8795-1478400cbd7a",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "40a96d63-9b95-4425-a6b6-ba3b8b37bca1",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "db3dff1a-7afa-4d60-a1d2-7af16fb7c640",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "8b73e2bc-d928-480c-a4e2-242516454cb1",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "33969c97-cfb8-4fa9-886f-15226447606e",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      }, {
+        "id" : "ea1ffa34-1cdc-4221-8244-3be71e11b2d8",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "reports-api" : [ ],
+      "broker" : [ {
+        "id" : "2d77058c-f022-48f7-bc1c-2890084f485b",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "38b167a2-b078-4a6e-8614-3b9a399c871b",
+        "attributes" : { }
+      } ],
+      "reports-frontend" : [ ],
+      "account" : [ {
+        "id" : "452e6764-6ece-4ff0-8a85-b06c4fac77c4",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "a066a924-7521-4e2d-9fbd-2e57d714e372",
+        "attributes" : { }
+      }, {
+        "id" : "a450dbbc-94fa-4efd-894a-1feb83d7050b",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "a066a924-7521-4e2d-9fbd-2e57d714e372",
+        "attributes" : { }
+      }, {
+        "id" : "c6fdbbc8-cbee-4105-83f4-570c54321535",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "a066a924-7521-4e2d-9fbd-2e57d714e372",
+        "attributes" : { }
+      }, {
+        "id" : "8c67dfa2-2718-42fb-bdd4-75f2b7348403",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "a066a924-7521-4e2d-9fbd-2e57d714e372",
+        "attributes" : { }
+      }, {
+        "id" : "6c2c306e-9959-4687-b3da-59f68827c485",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "a066a924-7521-4e2d-9fbd-2e57d714e372",
+        "attributes" : { }
+      }, {
+        "id" : "4160eadf-caed-444c-988e-a587f3403f0d",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "a066a924-7521-4e2d-9fbd-2e57d714e372",
+        "attributes" : { }
+      }, {
+        "id" : "7a72b2d5-c34d-49ae-8c94-777100251a5d",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "a066a924-7521-4e2d-9fbd-2e57d714e372",
+        "attributes" : { }
+      }, {
+        "id" : "985765f8-2a31-4324-91f1-b48f840ba100",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "a066a924-7521-4e2d-9fbd-2e57d714e372",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ {
+    "id" : "805d208a-b04c-4c4f-9319-7d227696f97b",
+    "name" : "prothetic_user",
+    "path" : "/prothetic_user",
+    "subGroups" : [ ],
+    "attributes" : { },
+    "realmRoles" : [ "prothetic_user" ],
+    "clientRoles" : { }
+  }, {
+    "id" : "836b249a-a290-4af1-8f1e-05418d5f3246",
+    "name" : "user",
+    "path" : "/user",
+    "subGroups" : [ ],
+    "attributes" : { },
+    "realmRoles" : [ "user" ],
+    "clientRoles" : { }
+  } ],
+  "defaultRole" : {
+    "id" : "b52c6a83-542b-44f4-8791-55256374f1f4",
+    "name" : "default-roles-reports-realm",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "95c0e286-4ae1-45ae-a251-21fc4a91d135"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 0,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppGoogleName", "totpAppMicrosoftAuthenticatorName" ],
+  "localizationTexts" : { },
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256", "RS256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyExtraOrigins" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256", "RS256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessExtraOrigins" : [ ],
+  "users" : [ {
+    "id" : "19b41c52-3466-40e5-a0e4-d0a1e6e274e6",
+    "username" : "admin1",
+    "firstName" : "Admin",
+    "lastName" : "One",
+    "email" : "admin1@example.com",
+    "emailVerified" : false,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "45c55b37-07e3-4670-85d1-0097b76eb4c4",
+      "type" : "password",
+      "createdDate" : 1786486108177,
+      "secretData" : "{\"value\":\"X1SggWQed/Y395UICAlRD+MKKTcc/AeIkaCcItzdo68=\",\"salt\":\"xJd8oQT7lPKXUmB+Ofb1ug==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ "CONFIGURE_TOTP" ],
+    "realmRoles" : [ "administrator" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "e4a0a4df-6ebc-45c6-ba1f-73873f364f97",
+    "username" : "alex.johnson",
+    "firstName" : "Alex",
+    "lastName" : "Johnson",
+    "email" : "alex@example.com",
+    "emailVerified" : false,
+    "attributes" : {
+      "LDAP_ENTRY_DN" : [ "uid=alex,ou=People,dc=example,dc=com" ],
+      "LDAP_ID" : [ "fd9f7fde-29f8-1041-8b1b-d91895111b9b" ]
+    },
+    "enabled" : true,
+    "origin" : "UCnL5qc2QnS91OUQVIjbtQ",
+    "createdTimestamp" : 1786486140814,
+    "totp" : false,
+    "federationLink" : "UCnL5qc2QnS91OUQVIjbtQ",
+    "credentials" : [ ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ "CONFIGURE_TOTP" ],
+    "realmRoles" : [ "default-roles-reports-realm" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "aab5ff67-117c-4d67-a85a-ca106e2c0baa",
+    "username" : "jane.smith",
+    "firstName" : "Jane",
+    "lastName" : "Smith",
+    "email" : "jane@example.com",
+    "emailVerified" : false,
+    "attributes" : {
+      "LDAP_ENTRY_DN" : [ "uid=jane.smith,ou=People,dc=example,dc=com" ],
+      "LDAP_ID" : [ "fd9f29e4-29f8-1041-8b1a-d91895111b9b" ]
+    },
+    "enabled" : true,
+    "origin" : "UCnL5qc2QnS91OUQVIjbtQ",
+    "createdTimestamp" : 1786486140810,
+    "totp" : false,
+    "federationLink" : "UCnL5qc2QnS91OUQVIjbtQ",
+    "credentials" : [ ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ "CONFIGURE_TOTP" ],
+    "realmRoles" : [ "default-roles-reports-realm" ],
+    "notBefore" : 0,
+    "groups" : [ "/user" ]
+  }, {
+    "id" : "c2f435fd-2609-4082-95af-348b4f43be9c",
+    "username" : "john.doe",
+    "firstName" : "John",
+    "lastName" : "Doe",
+    "email" : "john@example.com",
+    "emailVerified" : false,
+    "attributes" : {
+      "LDAP_ENTRY_DN" : [ "uid=john.doe,ou=People,dc=example,dc=com" ],
+      "LDAP_ID" : [ "fd9f050e-29f8-1041-8b19-d91895111b9b" ]
+    },
+    "enabled" : true,
+    "origin" : "UCnL5qc2QnS91OUQVIjbtQ",
+    "createdTimestamp" : 1786486140804,
+    "totp" : false,
+    "federationLink" : "UCnL5qc2QnS91OUQVIjbtQ",
+    "credentials" : [ ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ "CONFIGURE_TOTP" ],
+    "realmRoles" : [ "default-roles-reports-realm" ],
+    "notBefore" : 0,
+    "groups" : [ "/prothetic_user" ]
+  }, {
+    "id" : "cae67af0-0afb-4f95-8174-f6f04812668d",
+    "username" : "prothetic1",
+    "firstName" : "Prothetic",
+    "lastName" : "One",
+    "email" : "prothetic1@example.com",
+    "emailVerified" : false,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "703a0b49-bc60-4982-8829-4f48647cb2af",
+      "type" : "password",
+      "createdDate" : 1786486108198,
+      "secretData" : "{\"value\":\"iGVKnmVYxuMOqaxfzWa75p246zOQNwGmmrnWxn1eG2k=\",\"salt\":\"PfhxaYKJ7+4nlx08kyx7wg==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ "CONFIGURE_TOTP" ],
+    "realmRoles" : [ "prothetic_user" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "0dfca9b9-0a7f-45ea-96ad-09bc018f72f8",
+    "username" : "prothetic2",
+    "firstName" : "Prothetic",
+    "lastName" : "Two",
+    "email" : "prothetic2@example.com",
+    "emailVerified" : false,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "5ea1ad7a-8a63-44fa-bebf-1dad4b2baad9",
+      "type" : "password",
+      "createdDate" : 1786486108219,
+      "secretData" : "{\"value\":\"USl2VPxpyFyXxalerI+hFVmU45caD/+yTA4rFe1Q7pU=\",\"salt\":\"TkmEos7sWzRK4uKoztiXWg==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ "CONFIGURE_TOTP" ],
+    "realmRoles" : [ "prothetic_user" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "5c62cd84-43a0-4ac4-a07f-65256c8794fe",
+    "username" : "prothetic3",
+    "firstName" : "Prothetic",
+    "lastName" : "Three",
+    "email" : "prothetic3@example.com",
+    "emailVerified" : false,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "5110e959-d13c-4f09-afc1-23ab57589d66",
+      "type" : "password",
+      "createdDate" : 1786486108242,
+      "secretData" : "{\"value\":\"TNBArYVc7qao7Cn4vZ3KjzSFfUTNVAvwNOoYRqni/mc=\",\"salt\":\"/XKGBV966J4Hsl7I5a5lng==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ "CONFIGURE_TOTP" ],
+    "realmRoles" : [ "prothetic_user" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "ad11441d-4e7f-41a9-a7ce-91fa3e24346f",
+    "username" : "user1",
+    "firstName" : "User",
+    "lastName" : "One",
+    "email" : "user1@example.com",
+    "emailVerified" : false,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "19148fbe-6e17-4514-907d-01ec86614597",
+      "type" : "password",
+      "createdDate" : 1786486108127,
+      "secretData" : "{\"value\":\"rm5ScNiDjWnXADGsNNov/LrMpzNfufeo7ASRYSH29Lg=\",\"salt\":\"7xbJMvwRvbiKgHG8ixO8IQ==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ "CONFIGURE_TOTP" ],
+    "realmRoles" : [ "user" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "79332bdb-ad9c-46dc-b340-f595b46308f8",
+    "username" : "user2",
+    "firstName" : "User",
+    "lastName" : "Two",
+    "email" : "user2@example.com",
+    "emailVerified" : false,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "54d4ae78-3fe9-4429-9162-388cb9d8c573",
+      "type" : "password",
+      "createdDate" : 1786486108158,
+      "secretData" : "{\"value\":\"Ic0smtcCu52R4kvYL9j/I7rIu23ShAjfcah06qY8GTY=\",\"salt\":\"0aS4tj1xLudLS2jgKRmCZg==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ "CONFIGURE_TOTP" ],
+    "realmRoles" : [ "user" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  } ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account", "view-groups" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "a066a924-7521-4e2d-9fbd-2e57d714e372",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/reports-realm/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/reports-realm/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "96c26bb5-f64c-411d-aaac-570d65228f66",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/reports-realm/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/reports-realm/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "663969ec-5c6f-4938-8a8e-3de05961984c",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "4d481dc9-51e3-4c4f-be1c-ba04371c2eb9",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "client.use.lightweight.access.token.enabled" : "true"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "38b167a2-b078-4a6e-8614-3b9a399c871b",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "true"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "fc775e48-a629-4bca-9fa0-1aaff5aa69cc",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "true"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "2094a441-10b8-42fc-b4b9-e3f5867415fe",
+    "clientId" : "reports-api",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "865b4296-a1e9-45c3-b8a3-0e7c303ab4cf",
+    "clientId" : "reports-frontend",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "http://localhost:4000/callback" ],
+    "webOrigins" : [ "http://localhost:4000" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "0d737029-81c2-4260-a553-73fd3f37249a",
+      "name" : "reports-api-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "reports-api",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "false"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "35b808f4-5956-40f5-a74b-842b3619c2ed",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/reports-realm/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/reports-realm/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "client.use.lightweight.access.token.enabled" : "true",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "d4bf9501-b9ce-45c0-be80-27b283f4052b",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "fec5e03c-ffb3-4efc-b477-9211dec6057c",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "83bf68f5-0490-489e-b720-cd51deaa9dba",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "356b473e-d34b-47a6-a686-16db54a2ac03",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "c917b57e-0ab4-4a53-af3a-355281576586",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "31749796-c8e9-4ec5-97c2-7149970b4c20",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "introspection.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "c3c427fe-3a05-4e3b-8060-112c7b55a1d6",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "9309a5d5-31ff-4f90-b5e6-6e3780371dbb",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "c0a1932c-0024-43cf-958b-cd0e708ed482",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "consent.screen.text" : "${rolesScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "757174a2-85b3-43b8-86e7-d8e4f8c9bfe8",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "8ba4f14a-8766-4b20-8759-8966721d5fb2",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "f77c7772-c4bb-4734-9d5d-abcc70d7a3d5",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "117fb7e0-1604-4acf-b163-fbe14fba5a7d",
+    "name" : "organization",
+    "description" : "Additional claims about the organization a subject belongs to",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${organizationScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "312f9a07-e3fa-4adf-aa08-333e876efae1",
+      "name" : "organization",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-organization-membership-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "organization",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "4c0ee4cf-fe19-4c7f-9aa8-a2372e608b2f",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "30962f7e-5ffc-4ab5-be2d-3996da2136b3",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "multivalued" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "40a2f3d3-6355-4d82-978c-3144538f920e",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "3005a34e-e9f8-4282-b661-a1f66e715ac9",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "8f1c51a6-d89a-4972-a719-9da385f07706",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "introspection.token.claim" : "true",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "05fa965c-92ee-4b77-9ab0-ae51be3a8c8a",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "c416350b-bd28-4868-baf2-01a1b0ce4c05",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "01ba964b-4d70-4e0f-a9d6-5cccddfbcb8a",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f82f989d-d0fc-4f24-9955-23ac46714984",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f806a0ec-bc24-4c4e-9a27-09d3ab1b00eb",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "2222090d-7baf-47a5-ac58-cd2d29af1a3d",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "10663a30-3ec9-4918-bb70-2f9d20f08365",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "31bed695-7f3f-416d-9c1f-260f21ed3c5c",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "6ecf90f7-da95-4141-9d30-5041dc09cb0e",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5bb412c9-29b3-466e-b2f5-0c010c380ff5",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "360c3b0c-eb53-41b9-9ecc-554818f7fcb9",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "faf70705-24e2-4360-936c-17175ac2f08e",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4f1a3d17-43bd-4f63-8354-6d2c30ea190f",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4863a37f-2482-407f-b38d-df803bfa4def",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "726f9d4d-0147-45e4-8676-41f0a6e4de05",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "d06afa11-4630-4b72-a93f-14eca6336029",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "ee67f244-8368-4225-b01e-d4c1dcb3da18",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "b7b91ea5-88fe-46ab-baf4-8859e5893662",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e09d2b34-1048-4cb2-8b72-863f2f03245a",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "6d2e9cf5-3d00-42f2-9aa9-dd813ced9654",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "consent.screen.text" : "",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "50a0e6fe-f49b-4e7e-afc7-9da53544ba29",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "access.token.claim" : "true",
+        "introspection.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "6b9ea127-5d9f-4897-950e-c7dfca43e6ec",
+    "name" : "service_account",
+    "description" : "Specific scope for a client enabled for service accounts",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "cbb336b9-b27f-40f0-8fa7-db83b8a44aab",
+      "name" : "Client IP Address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientAddress",
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientAddress",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "56036a61-d417-49e0-9a78-bcf25eac34df",
+      "name" : "Client Host",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientHost",
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientHost",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d16873bf-2235-4e0b-a322-8a3e711ccb16",
+      "name" : "Client ID",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "client_id",
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "client_id",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "992e1332-5252-4a1b-8980-4877e6921de4",
+    "name" : "saml_organization",
+    "description" : "Organization Membership",
+    "protocol" : "saml",
+    "attributes" : {
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "b4f19f99-bbea-44cd-a89d-3794a0ac539d",
+      "name" : "organization",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-organization-membership-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "d8d1695b-9fd4-40b5-bd42-957ba2602ee6",
+    "name" : "basic",
+    "description" : "OpenID Connect scope for add all basic claims to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "57885978-d510-4233-a98d-1a28ea6f40ec",
+      "name" : "sub",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-sub-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "19328242-b6ec-42c8-a380-c47ffa14a87d",
+      "name" : "auth_time",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "AUTH_TIME",
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "auth_time",
+        "jsonType.label" : "long"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "saml_organization", "profile", "email", "roles", "web-origins", "acr", "basic" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt", "organization" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "referrerPolicy" : "no-referrer",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ {
+    "alias" : "yandex",
+    "displayName" : "Yandex ID",
+    "internalId" : "a938a2c5-217c-40a0-9c93-8b557f4a59cd",
+    "providerId" : "oauth2",
+    "enabled" : true,
+    "updateProfileFirstLoginMode" : "on",
+    "trustEmail" : false,
+    "storeToken" : true,
+    "addReadTokenRoleOnCreate" : false,
+    "authenticateByDefault" : false,
+    "linkOnly" : false,
+    "hideOnLogin" : false,
+    "firstBrokerLoginFlowAlias" : "first broker login",
+    "config" : {
+      "userInfoUrl" : "https://login.yandex.ru/info",
+      "clientId" : "REPLACE_WITH_YANDEX_OAUTH_CLIENT_ID",
+      "tokenUrl" : "https://oauth.yandex.ru/token",
+      "authorizationUrl" : "https://oauth.yandex.ru/authorize",
+      "syncMode" : "IMPORT",
+      "userIDClaim" : "id",
+      "clientAuthentication" : "client_secret_post",
+      "clientSecret" : "REPLACE_WITH_YANDEX_OAUTH_CLIENT_SECRET",
+      "emailClaim" : "default_email",
+      "userNameClaim" : "login",
+      "defaultScope" : "login:email login:info"
+    }
+  } ],
+  "identityProviderMappers" : [ {
+    "id" : "018f3284-f58e-4e8c-85ea-78228d90c665",
+    "name" : "email",
+    "identityProviderAlias" : "yandex",
+    "identityProviderMapper" : "oidc-user-attribute-idp-mapper",
+    "config" : {
+      "userAttribute" : "email",
+      "jsonField" : "default_email"
+    }
+  }, {
+    "id" : "7fa8840c-cdb1-4bae-ab26-f788ed6a0564",
+    "name" : "first-name",
+    "identityProviderAlias" : "yandex",
+    "identityProviderMapper" : "oidc-user-attribute-idp-mapper",
+    "config" : {
+      "userAttribute" : "firstName",
+      "jsonField" : "first_name"
+    }
+  }, {
+    "id" : "a1007853-b94e-4e67-b49c-dc8e68071007",
+    "name" : "last-name",
+    "identityProviderAlias" : "yandex",
+    "identityProviderMapper" : "oidc-user-attribute-idp-mapper",
+    "config" : {
+      "userAttribute" : "lastName",
+      "jsonField" : "last_name"
+    }
+  }, {
+    "id" : "d01e5828-b342-4201-bf8a-c04e8b999fec",
+    "name" : "yandex-login",
+    "identityProviderAlias" : "yandex",
+    "identityProviderMapper" : "oidc-user-attribute-idp-mapper",
+    "config" : {
+      "userAttribute" : "yandex_login",
+      "jsonField" : "login"
+    }
+  } ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "2ce5e53b-8cce-41e1-b0f9-8339e62cb97e",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-property-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper", "oidc-full-name-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "saml-role-list-mapper" ]
+      }
+    }, {
+      "id" : "8bbee7bf-e521-41c3-ba2b-92d111436785",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "07a4d33b-9083-4690-9042-70441c39754f",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "a02af38f-de10-41b0-a199-6d80aabab51b",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "eeb54825-741a-47f8-9107-2a3c95d9aad5",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "34216a05-4c55-42db-97ac-398c2c1d73c0",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "oidc-full-name-mapper", "saml-user-property-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-attribute-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "saml-user-attribute-mapper" ]
+      }
+    }, {
+      "id" : "7a31ae8f-64ce-4a35-b7f8-46f411c01887",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "0dc33a5b-e95a-4a55-b973-eb73bd2a5509",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    } ],
+    "org.keycloak.storage.UserStorageProvider" : [ {
+      "id" : "UCnL5qc2QnS91OUQVIjbtQ",
+      "name" : "representative-office-ldap",
+      "providerId" : "ldap",
+      "subComponents" : {
+        "org.keycloak.storage.ldap.mappers.LDAPStorageMapper" : [ {
+          "id" : "35a9957d-31c0-48bd-829b-01db740f4a4d",
+          "name" : "username",
+          "providerId" : "user-attribute-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "ldap.attribute" : [ "uid" ],
+            "is.mandatory.in.ldap" : [ "true" ],
+            "always.read.value.from.ldap" : [ "false" ],
+            "read.only" : [ "true" ],
+            "user.model.attribute" : [ "username" ]
+          }
+        }, {
+          "id" : "eba7a131-893a-4876-aba3-75c8d5fe3553",
+          "name" : "representative-office-groups",
+          "providerId" : "group-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "mode" : [ "READ_ONLY" ],
+            "membership.attribute.type" : [ "DN" ],
+            "user.roles.retrieve.strategy" : [ "LOAD_GROUPS_BY_MEMBER_ATTRIBUTE" ],
+            "groups.ldap.filter" : [ "" ],
+            "group.name.ldap.attribute" : [ "cn" ],
+            "membership.user.ldap.attribute" : [ "uid" ],
+            "membership.ldap.attribute" : [ "member" ],
+            "preserve.group.inheritance" : [ "false" ],
+            "groups.dn" : [ "ou=Groups,dc=example,dc=com" ],
+            "group.object.classes" : [ "groupOfNames" ],
+            "drop.non.existing.groups.during.sync" : [ "false" ],
+            "mapped.group.attributes" : [ "" ]
+          }
+        }, {
+          "id" : "d0350ab6-7bfc-4efb-ba10-7d3bce07414d",
+          "name" : "last name",
+          "providerId" : "user-attribute-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "ldap.attribute" : [ "sn" ],
+            "is.mandatory.in.ldap" : [ "true" ],
+            "read.only" : [ "true" ],
+            "always.read.value.from.ldap" : [ "true" ],
+            "user.model.attribute" : [ "lastName" ]
+          }
+        }, {
+          "id" : "c91b2789-ba6a-45dc-b7c8-c4fb08c2b10c",
+          "name" : "first name",
+          "providerId" : "user-attribute-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "ldap.attribute" : [ "cn" ],
+            "is.mandatory.in.ldap" : [ "true" ],
+            "read.only" : [ "true" ],
+            "always.read.value.from.ldap" : [ "true" ],
+            "user.model.attribute" : [ "firstName" ]
+          }
+        }, {
+          "id" : "630dacde-29a1-4b56-bb6d-080a576d85a0",
+          "name" : "email",
+          "providerId" : "user-attribute-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "ldap.attribute" : [ "mail" ],
+            "is.mandatory.in.ldap" : [ "false" ],
+            "always.read.value.from.ldap" : [ "true" ],
+            "read.only" : [ "true" ],
+            "user.model.attribute" : [ "email" ]
+          }
+        } ]
+      },
+      "config" : {
+        "pagination" : [ "true" ],
+        "fullSyncPeriod" : [ "-1" ],
+        "searchScope" : [ "2" ],
+        "useTruststoreSpi" : [ "never" ],
+        "usersDn" : [ "ou=People,dc=example,dc=com" ],
+        "connectionPooling" : [ "true" ],
+        "trustEmail" : [ "false" ],
+        "priority" : [ "1" ],
+        "importEnabled" : [ "true" ],
+        "enabled" : [ "true" ],
+        "userObjectClasses" : [ "inetOrgPerson, organizationalPerson" ],
+        "bindCredential" : [ "admin" ],
+        "usernameLDAPAttribute" : [ "uid" ],
+        "changedSyncPeriod" : [ "-1" ],
+        "bindDn" : [ "cn=admin,dc=example,dc=com" ],
+        "rdnLDAPAttribute" : [ "uid" ],
+        "lastSync" : [ "1786486140" ],
+        "vendor" : [ "other" ],
+        "editMode" : [ "READ_ONLY" ],
+        "uuidLDAPAttribute" : [ "entryUUID" ],
+        "allowKerberosAuthentication" : [ "false" ],
+        "connectionUrl" : [ "ldap://openldap:389" ],
+        "syncRegistrations" : [ "false" ],
+        "authType" : [ "simple" ],
+        "batchSizeForSync" : [ "1000" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "4890e35c-a2b3-4a31-b1b9-9acd999fe39e",
+      "name" : "hmac-generated-hs512",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "f24ccab5-6465-456a-b88e-f1a4dfaa4a49" ],
+        "secret" : [ "t2E7OXjCzJzFAB49wnr6_7Yz8wGjzZX099usN1EquP1HgTEufaL80RHVLZUeSkbTuGlCoQIqj0lte_oQBLiKiDeWPysGyhpJ8S_IJg6nrk9lRjL1SFIdNg1vI5a4aadPsuSwsef7T-I24Oyt0aJ2n2wAC28mhFIB3DBEOpq6oYU" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS512" ]
+      }
+    }, {
+      "id" : "02a9e285-f183-4661-9778-82e9a93d68e8",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEogIBAAKCAQEAwO0FcT5klrpNxDo7+M8zZDg9k/9fG+1Cy19mfCApBS2p7zOTfyIvYtAG+QWevBW3d9WmfL8SeIpttHcTNBlyYWp5Bltkf4QJJBVCOsilFtDr+jyGu+VXxKub8Nt35iysfEm3H4UQ/mG4FCGW7D9wxRx/3N1XI/2pbPAi1whxvECtwRPzrDm8h1QPIMPP/qpsVi0x/MksR+kSFCS2O24nGLIvVy6xdcZu3llPj+WATBHXIt3cu06zDR6838SES9KLq+aD82nOwCNR1urSG+nfUnZXMtfylPrvBwy77BpdiKeUgtcbFIueUV48L9gthNiyJ4WOZQTsdROrodkTSHZHsQIDAQABAoH/b4iXnOB1Rq5uRwNjqHQhQc9Byk3Yrkx8URbWKOxuyo+brq4il10sB/Q8E7ssCZCEgMMDfRr5krZ0teAhOf18ItVrIkGz2AR9RF8F6vYUexxNUF2thvMPyqNrg9NdfbRWA4SaWZ6UNHxJ71l75xjGGS5gvU85EZWUXWZ2vdoj5rB8axTskUdyEfYmXJdkPtW3xrNq0KEEC0ZuKNrYxU+DIJaL81Mq0tSYXaISfQd1jpoX2yhJcvNKw5r3ZwKJZEWq1Hlmri2A+RUfB0KMq4fCaF+CkyV90u8TkcOFdK09ZYvlZ7QdUTDqZWW40TXBaXF2g18USQONI+Rd3XbrYJcRAoGBAOq1O/VHD8WY59f/9LWGn2bqpe/x1A0L2+2XuE7Dg0Qb3ObdxjVlo5kGU6Uyr/IRhOagWS53npxG0olsqNznI9t82GclVEFxOeP5wCgc2jsMHAEy1x8TLpsWdm8X3hSHn6ZjgMC+9BNNEqdhbXlUQvYuou3xqQZYPvzyQVd3QWhbAoGBANJtdM6RyRO7jm3roo6kn9dj4pld55OxK3UICcxwufb8qN/CR2qCTVqxkr7pJFlSqThdwrQiaZ4v/Rl9hwClA1fKfGpgHCb+VIJtzf0k+iRhzKPtkgJCysU7Pe1QbvlPPQuckf6fcRYb+Fmf1PTYBmIaCWLGOZZHTp3PBRROmG3jAoGBAKW4pcdAD7DTkBABmAV8Mpz2XYgYVkOH9hfCos5qWgsDKWyRdtxJEcSApRrluTnQiOhWm+GlcIajsxB5epnPUpAtjJb30pAKpHeF5tnr1WMP384w2ZgFcUjsCV/TmGkigeV4KHbv3WKrbtpkfmnGxykQMNaVZWUndgIgA2cAu1w1AoGAZjniiw/r3Xg6Y1Ab8qwrMtpFlTg3blqdwAcdq4H/9escp0ecpjOTHMIzhieBDxvHNajnE9e786tgi+edlESV8SpfctYqFw9rQsnRTm+OTeptHh4l1o9YLqTvGsD+iINkJqXzjv0qVRFVf0TUkfX4c+QuNxwRkd4mZSfTUeA00P0CgYEAnIJzz4LIZw3RiJMfKxO41mmowjRN975J/rJiQyXfycTpZ8naCIBcOrCKzVVpjlQjjAFcWnyUmATQEK2Xbrbss242UI8qMNPYhE6i4dxkmGYrg7A4nBK+aTcy5DWdA+hIvAAP6o5JgBVlSQXPNWZZDxcYSJ8ZV2nGfg19vlJwCp4=" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIICqTCCAZECBgGf8t6w6TANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDDA1yZXBvcnRzLXJlYWxtMB4XDTI2MDgxMTIyMDY0OFoXDTM2MDgxMTIyMDgyOFowGDEWMBQGA1UEAwwNcmVwb3J0cy1yZWFsbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMDtBXE+ZJa6TcQ6O/jPM2Q4PZP/XxvtQstfZnwgKQUtqe8zk38iL2LQBvkFnrwVt3fVpny/EniKbbR3EzQZcmFqeQZbZH+ECSQVQjrIpRbQ6/o8hrvlV8Srm/Dbd+YsrHxJtx+FEP5huBQhluw/cMUcf9zdVyP9qWzwItcIcbxArcET86w5vIdUDyDDz/6qbFYtMfzJLEfpEhQktjtuJxiyL1cusXXGbt5ZT4/lgEwR1yLd3LtOsw0evN/EhEvSi6vmg/NpzsAjUdbq0hvp31J2VzLX8pT67wcMu+waXYinlILXGxSLnlFePC/YLYTYsieFjmUE7HUTq6HZE0h2R7ECAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAWOt1nKqIF6QFSwQKcyiNl8+L3xfZ2bY+Gc0Or8bqeDNLJaB8/qOej31tR7jJtU2GfPCa5tV+Z0xcc8u/aeR04WhOKOVd99yTsegFTwzA78/T9EUYWpxAy4PH7Kv0rz5AtfIWY8/HLp+53SnGLERNOm27e/kPZby6xdX8z5PapHY1UJgOTspkjWMDQ6xS/0mB6G40odylzRBciYd79MGeOr2HQtjMCk99ued3fqJbeO9Rde24Ze33qD0a7MjKlIGL7JmDtaUve03zH+A9KNhprF2oAP6YvA1AcxIZDLsCzIXb7ems8c5hy8eInr/4aAtAD9r2NAKAYClsj/sjGMUUDw==" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "4f6b19ae-5a32-47a2-939a-e2c1a5e53081",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "401989bc-4b0b-441d-a2e7-5718c9545b79" ],
+        "secret" : [ "0tgT4xqdnahFngyhc-N-mA" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "1ff85828-d749-475f-a2e8-6ff6a0dc8574",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEArtr0wHqW5s0nz5XSyaS5bT9tPhmb6Da8RtB79oX1Fb2W/SZZB7mTTpM0mfO+Ee7y26pazf3Py5SD23UCVjqX6aCYsoF5MJmtZKKYOgVPSK8tJCiqDB5hZ1Wd+X4jicwSKfls7vWGo7/IypryXMwy/OFPLJnNCWnlbHQ85z61Mu1JOxOrDFS/LtTfUQ362JvEHK/mm2vfB7jxzbC9KqUK98yhlyPO7D6z+9MMS+qFEStBaDZ2okPw91H+mMqoGRZd3xgqJYxl71AApFBil9U4cFd4iF+mJLCEdy4JSd4xfl40T9w47rY2IODiPUUFfW7M4dVcG9sYrBUprSofvvJ7yQIDAQABAoIBABNrAW82rfdnpRoqe0QlZOo69vjEg0ngejwq/vk7myIU8eWfEpgHBdLeCiNmrB71uEaovnjNzPvAvHvsnJvS2ff5+7snIbxB9L2OSPV4jXt26L5xPaEm5o5BNc/1MCEnZoT+zBglcBRTQgst9ehUTP1EUDSVx+1Zsz6+Ed1kW18SR5/hioL1mnokhc0Elql4NaMpGnj654DEfDlPpKaWlBwhVaITluhF6kU1/J20o1jLJGjhG+A2C6wMdEgRKfqW1lsQp6B1CLddLK5/nkrK9rvFDpjJ/XQAGHz4L+BFhXgd82X3QX6kS+b2iahY69LSaDk1kMjW38P5gBa1sygUwjkCgYEA7AAO/qlOpatw27rCHjQFmAcKwOmv2gIH3NspwAjloLGVdLJ72HHJ+gSBVSDbXHJJ2nbrQLOL1tQ8u9lsiVv8Jm7nqgN3JCsk0M0xCcigGXhmmo1ivPOTgKjvB518C5nSfS6ak6kbfnZ0Obs5Pi6+0hj2oaXAP3d6uYLQPnXhX2sCgYEAvaxhPSW+7SHIDWG7YFWN1QPAGpOBnOrRnlibvjtPvykcT3SMEetWUQk/yFgb2tWqRsrUb1x3Ypfboh9X235kis4j4jsaoetbX9RwSnGZYoxQdWB7G8Xq1r6s3KdW5rtpePG/ctXTwFg9yLJa/EoJSTy+BCxAHLXuOLkYvdZUopsCgYArtY8RZ3YjhO8wIxTU1zm6AIPjWuSw8fNW2liPMpak/n750BzT569K2Q7DH4TBSIGZLrE/mIFr1n8xI4HQpvK6g4vwlxe34S2+ZmKQt1G/pecK9Oi2qj5FdARhWq+gzmqHuNv0QTvQXkwEbUKa27mH3AvBwJsspgpa1XmQN/D35QKBgQCGKqdl74tMhfbSsG0wyZPYOBztL6Yhb2Dzl04jlCTm3ZevBIwIKOYX0GkTuG+LrlQSW2tFkqzISw8LcQxesNtB7GspnhFKtAcglE8R+aU8NnC7dpHepXNmj94K/zvTXoJPEQIRovt0NXcOvkrp5x0GdzcaEIsRRAfMi/HaZv/bPQKBgAJd4h75sNELDNm4x0etpma0YUaAwY1+ldJ8ZjG25gqt/CkZqHziV6IgCPgdG2fjRZ2Vog07cmFUhfk7m/y3DNxm71HUEwQm8XLBgLIDCvxQuC2HMNZvFSCJKAKpxz9B7lqijaPJi6PHazHrw+7NwS/fClPYIGct3wtnzaMOiS9b" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIICqTCCAZECBgGf8t6xvDANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDDA1yZXBvcnRzLXJlYWxtMB4XDTI2MDgxMTIyMDY0OFoXDTM2MDgxMTIyMDgyOFowGDEWMBQGA1UEAwwNcmVwb3J0cy1yZWFsbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK7a9MB6lubNJ8+V0smkuW0/bT4Zm+g2vEbQe/aF9RW9lv0mWQe5k06TNJnzvhHu8tuqWs39z8uUg9t1AlY6l+mgmLKBeTCZrWSimDoFT0ivLSQoqgweYWdVnfl+I4nMEin5bO71hqO/yMqa8lzMMvzhTyyZzQlp5Wx0POc+tTLtSTsTqwxUvy7U31EN+tibxByv5ptr3we48c2wvSqlCvfMoZcjzuw+s/vTDEvqhRErQWg2dqJD8PdR/pjKqBkWXd8YKiWMZe9QAKRQYpfVOHBXeIhfpiSwhHcuCUneMX5eNE/cOO62NiDg4j1FBX1uzOHVXBvbGKwVKa0qH77ye8kCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAM1AZ9yLLWcrF7gDZGeymnUxsMqVhepIlVnwdp/ILrJ4a7vz+VNRdTfF7ZV7/qY4DmWlVeHpjWazUrb5OgpWnx8soOVujRSalfN8YcYeMRxyS8u7is7rSYQujLLRvbKK88MQLtLMCMhC+plu5gVJN/5Z4JxYHmdAa+KPScorAAyjrhl+KGupdSDWLWw6O7glz4HlUrnAN5pjlFWnFd6gzRalPpk8ig3tMr9bENwVOU+KeTR3SH9IEMSLApzzmT4dnGD2JpL9UQKh6NTb0Z4pN+tNORM51zWw3oxJrdrgg5kLM9zzJjpq7lzRXnH5p+ELYAdA4Oh18suMpaZ5ckEZSjQ==" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "authenticationFlows" : [ {
+    "id" : "5d4527a9-68f1-4d89-904f-9e5bae99e77a",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "16e83c14-d2ef-461f-b6a8-1074c652ded8",
+    "alias" : "Browser - Conditional 2FA",
+    "description" : "Flow to determine if any 2FA is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "webauthn-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-recovery-authn-code-form",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "5dc24b46-1a0c-47b6-89fa-d5889f5d7c20",
+    "alias" : "Browser - Conditional Organization",
+    "description" : "Flow to determine if the organization identity-first login is to be used",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "organization",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "34e53a1f-0407-49a6-a121-27b53e70233a",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "579fcd26-38ab-47dd-aa8a-984f8da10722",
+    "alias" : "First Broker Login - Conditional Organization",
+    "description" : "Flow to determine if the authenticator that adds organization members is to be used",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "idp-add-organization-member",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "a0b02c83-1d97-41fa-8bf9-83eb79d99bf1",
+    "alias" : "First broker login - Conditional 2FA",
+    "description" : "Flow to determine if any 2FA is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "webauthn-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-recovery-authn-code-form",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "8dffb95f-d535-4947-b040-614eaf952563",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d072bb1b-eb20-4471-a721-2dc4702a5936",
+    "alias" : "Organization",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional Organization",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "3359356c-07cb-4adc-b433-cacc892d31e0",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "08201e7f-26df-4bfb-8904-79472fab2626",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ae700c70-5fa9-4351-9431-ae9f6340bacb",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional 2FA",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "9ba5259c-366a-4b7f-b49e-86e20f7a5306",
+    "alias" : "browser",
+    "description" : "Browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 26,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Organization",
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "9e478ad8-3e89-4814-9d7e-9e8d52cf923e",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "f5de64f3-cf40-4754-b694-6a7b917e9fd7",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "791c00ac-c703-43dc-9711-b721858ff8af",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "40a08542-88d9-49e4-a83f-d296210cbe31",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 50,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First Broker Login - Conditional Organization",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "f8bb8cdf-baf4-4463-adc5-e23db8223d1f",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional 2FA",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "88be35e9-98d5-4291-90a6-bfdb444aa19c",
+    "alias" : "registration",
+    "description" : "Registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "0da42195-b86d-4e5d-89de-2f5dfb7a7056",
+    "alias" : "registration form",
+    "description" : "Registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-terms-and-conditions",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 70,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "83e970e5-f3af-4d1a-b169-fcb7207ed95e",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "f62297be-7b0e-4dbd-8089-03447c691a63",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "ac4de410-49ec-4e8f-88ad-9d9e6d44b19f",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "9e5ad05e-d09a-4368-8995-181d798a3533",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : true,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "firstBrokerLoginFlow" : "first broker login",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "oauth2DeviceCodeLifespan" : "600",
+    "oauth2DevicePollingInterval" : "5",
+    "parRequestUriLifespan" : "60",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false"
+  },
+  "keycloakVersion" : "26.3.5",
+  "userManagedAccessAllowed" : false,
+  "organizationsEnabled" : false,
+  "verifiableCredentialsEnabled" : false,
+  "adminPermissionsEnabled" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}

--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -1,129 +1,352 @@
 {
-    "realm": "reports-realm",
-    "enabled": true,
-    "roles": {
-      "realm": [
+  "realm": "reports-realm",
+  "enabled": true,
+  "sslRequired": "external",
+  "accessTokenLifespan": 120,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "revokeRefreshToken": true,
+  "refreshTokenMaxReuse": 0,
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyDigits": 6,
+  "otpPolicyPeriod": 30,
+  "otpPolicyInitialCounter": 0,
+  "otpSupportedApplications": ["FreeOTP", "Google Authenticator"],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": true,
+      "priority": 10,
+      "config": {}
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "user",
+        "description": "Regular user role"
+      },
+      {
+        "name": "administrator",
+        "description": "Administrator role"
+      },
+      {
+        "name": "prothetic_user",
+        "description": "Prothetic user role with report access"
+      }
+    ]
+  },
+  "groups": [
+    {
+      "name": "user",
+      "path": "/user",
+      "realmRoles": ["user"]
+    },
+    {
+      "name": "prothetic_user",
+      "path": "/prothetic_user",
+      "realmRoles": ["prothetic_user"]
+    }
+  ],
+  "users": [
+    {
+      "username": "user1",
+      "enabled": true,
+      "email": "user1@example.com",
+      "firstName": "User",
+      "lastName": "One",
+      "credentials": [
         {
-          "name": "user",
-          "description": "Regular user role"
-        },
+          "type": "password",
+          "value": "password123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": ["CONFIGURE_TOTP"],
+      "realmRoles": ["user"]
+    },
+    {
+      "username": "user2",
+      "enabled": true,
+      "email": "user2@example.com",
+      "firstName": "User",
+      "lastName": "Two",
+      "credentials": [
         {
-          "name": "administrator",
-          "description": "Administrator role"
-        },
+          "type": "password",
+          "value": "password123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": ["CONFIGURE_TOTP"],
+      "realmRoles": ["user"]
+    },
+    {
+      "username": "admin1",
+      "enabled": true,
+      "email": "admin1@example.com",
+      "firstName": "Admin",
+      "lastName": "One",
+      "credentials": [
         {
-          "name": "prothetic_user",
-          "description": "Prothetic user role with report access"
+          "type": "password",
+          "value": "admin123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": ["CONFIGURE_TOTP"],
+      "realmRoles": ["administrator"]
+    },
+    {
+      "username": "prothetic1",
+      "enabled": true,
+      "email": "prothetic1@example.com",
+      "firstName": "Prothetic",
+      "lastName": "One",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "prothetic123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": ["CONFIGURE_TOTP"],
+      "realmRoles": ["prothetic_user"]
+    },
+    {
+      "username": "prothetic2",
+      "enabled": true,
+      "email": "prothetic2@example.com",
+      "firstName": "Prothetic",
+      "lastName": "Two",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "prothetic123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": ["CONFIGURE_TOTP"],
+      "realmRoles": ["prothetic_user"]
+    },
+    {
+      "username": "prothetic3",
+      "enabled": true,
+      "email": "prothetic3@example.com",
+      "firstName": "Prothetic",
+      "lastName": "Three",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "prothetic123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": ["CONFIGURE_TOTP"],
+      "realmRoles": ["prothetic_user"]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "reports-frontend",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": ["http://localhost:4000/callback"],
+      "webOrigins": ["http://localhost:4000"],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "protocolMappers": [
+        {
+          "name": "reports-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "reports-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
         }
       ]
     },
-    "users": [
-      {
-        "username": "user1",
-        "enabled": true,
-        "email": "user1@example.com",
-        "firstName": "User",
-        "lastName": "One",
-        "credentials": [
-          {
-            "type": "password",
-            "value": "password123",
-            "temporary": false
-          }
-        ],
-        "realmRoles": ["user"]
-      },
-      {
-        "username": "user2",
-        "enabled": true,
-        "email": "user2@example.com",
-        "firstName": "User",
-        "lastName": "Two",
-        "credentials": [
-          {
-            "type": "password",
-            "value": "password123",
-            "temporary": false
-          }
-        ],
-        "realmRoles": ["user"]
-      },
-      {
-        "username": "admin1",
-        "enabled": true,
-        "email": "admin1@example.com",
-        "firstName": "Admin",
-        "lastName": "One",
-        "credentials": [
-          {
-            "type": "password",
-            "value": "admin123",
-            "temporary": false
-          }
-        ],
-        "realmRoles": ["administrator"]
-      },
-      {
-        "username": "prothetic1",
-        "enabled": true,
-        "email": "prothetic1@example.com",
-        "firstName": "Prothetic",
-        "lastName": "One",
-        "credentials": [
-          {
-            "type": "password",
-            "value": "prothetic123",
-            "temporary": false
-          }
-        ],
-        "realmRoles": ["prothetic_user"]
-      },
-      {
-        "username": "prothetic2",
-        "enabled": true,
-        "email": "prothetic2@example.com",
-        "firstName": "Prothetic",
-        "lastName": "Two",
-        "credentials": [
-          {
-            "type": "password",
-            "value": "prothetic123",
-            "temporary": false
-          }
-        ],
-        "realmRoles": ["prothetic_user"]
-      },
-      {
-        "username": "prothetic3",
-        "enabled": true,
-        "email": "prothetic3@example.com",
-        "firstName": "Prothetic",
-        "lastName": "Three",
-        "credentials": [
-          {
-            "type": "password",
-            "value": "prothetic123",
-            "temporary": false
-          }
-        ],
-        "realmRoles": ["prothetic_user"]
+    {
+      "clientId": "reports-api",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "oNwoLQdvJAvRcL89SydqCWCe5ry1jMgq",
+      "bearerOnly": true
+    }
+  ],
+  "identityProviders": [
+    {
+      "alias": "yandex",
+      "displayName": "Yandex ID",
+      "providerId": "oauth2",
+      "enabled": true,
+      "trustEmail": false,
+      "storeToken": true,
+      "addReadTokenRoleOnCreate": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "REPLACE_WITH_YANDEX_OAUTH_CLIENT_ID",
+        "clientSecret": "REPLACE_WITH_YANDEX_OAUTH_CLIENT_SECRET",
+        "authorizationUrl": "https://oauth.yandex.ru/authorize",
+        "tokenUrl": "https://oauth.yandex.ru/token",
+        "userInfoUrl": "https://login.yandex.ru/info",
+        "clientAuthentication": "client_secret_post",
+        "defaultScope": "login:email login:info",
+        "syncMode": "IMPORT",
+        "userIDClaim": "id",
+        "userNameClaim": "login",
+        "emailClaim": "default_email"
       }
-    ],
-    "clients": [
+    }
+  ],
+  "identityProviderMappers": [
+    {
+      "name": "email",
+      "identityProviderAlias": "yandex",
+      "identityProviderMapper": "oidc-user-attribute-idp-mapper",
+      "config": {
+        "jsonField": "default_email",
+        "userAttribute": "email"
+      }
+    },
+    {
+      "name": "first-name",
+      "identityProviderAlias": "yandex",
+      "identityProviderMapper": "oidc-user-attribute-idp-mapper",
+      "config": {
+        "jsonField": "first_name",
+        "userAttribute": "firstName"
+      }
+    },
+    {
+      "name": "last-name",
+      "identityProviderAlias": "yandex",
+      "identityProviderMapper": "oidc-user-attribute-idp-mapper",
+      "config": {
+        "jsonField": "last_name",
+        "userAttribute": "lastName"
+      }
+    },
+    {
+      "name": "yandex-login",
+      "identityProviderAlias": "yandex",
+      "identityProviderMapper": "oidc-user-attribute-idp-mapper",
+      "config": {
+        "jsonField": "login",
+        "userAttribute": "yandex_login"
+      }
+    }
+  ],
+  "components": {
+    "org.keycloak.storage.UserStorageProvider": [
       {
-        "clientId": "reports-frontend",
-        "enabled": true,
-        "publicClient": true,
-        "redirectUris": ["http://localhost:3000/*"],
-        "webOrigins": ["http://localhost:3000"],
-        "directAccessGrantsEnabled": true
-      },
-      {
-        "clientId": "reports-api",
-        "enabled": true,
-        "clientAuthenticatorType": "client-secret",
-        "secret": "oNwoLQdvJAvRcL89SydqCWCe5ry1jMgq", 
-        "bearerOnly": true
+        "name": "representative-office-ldap",
+        "providerId": "ldap",
+        "config": {
+          "enabled": ["true"],
+          "priority": ["1"],
+          "editMode": ["READ_ONLY"],
+          "syncRegistrations": ["false"],
+          "vendor": ["other"],
+          "usernameLDAPAttribute": ["uid"],
+          "rdnLDAPAttribute": ["uid"],
+          "uuidLDAPAttribute": ["entryUUID"],
+          "userObjectClasses": ["inetOrgPerson, organizationalPerson"],
+          "connectionUrl": ["ldap://openldap:389"],
+          "usersDn": ["ou=People,dc=example,dc=com"],
+          "authType": ["simple"],
+          "bindDn": ["cn=admin,dc=example,dc=com"],
+          "bindCredential": ["admin"],
+          "searchScope": ["2"],
+          "trustEmail": ["false"],
+          "useTruststoreSpi": ["never"],
+          "connectionPooling": ["true"],
+          "pagination": ["true"],
+          "allowKerberosAuthentication": ["false"],
+          "batchSizeForSync": ["1000"],
+          "fullSyncPeriod": ["-1"],
+          "changedSyncPeriod": ["-1"],
+          "importEnabled": ["true"]
+        },
+        "subComponents": {
+          "org.keycloak.storage.ldap.mappers.LDAPStorageMapper": [
+            {
+              "name": "username",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "ldap.attribute": ["uid"],
+                "user.model.attribute": ["username"],
+                "read.only": ["true"],
+                "always.read.value.from.ldap": ["false"],
+                "is.mandatory.in.ldap": ["true"]
+              }
+            },
+            {
+              "name": "email",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "ldap.attribute": ["mail"],
+                "user.model.attribute": ["email"],
+                "read.only": ["true"],
+                "always.read.value.from.ldap": ["true"],
+                "is.mandatory.in.ldap": ["false"]
+              }
+            },
+            {
+              "name": "first name",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "ldap.attribute": ["cn"],
+                "user.model.attribute": ["firstName"],
+                "read.only": ["true"],
+                "always.read.value.from.ldap": ["true"],
+                "is.mandatory.in.ldap": ["true"]
+              }
+            },
+            {
+              "name": "last name",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "ldap.attribute": ["sn"],
+                "user.model.attribute": ["lastName"],
+                "read.only": ["true"],
+                "always.read.value.from.ldap": ["true"],
+                "is.mandatory.in.ldap": ["true"]
+              }
+            },
+            {
+              "name": "representative-office-groups",
+              "providerId": "group-ldap-mapper",
+              "config": {
+                "groups.dn": ["ou=Groups,dc=example,dc=com"],
+                "group.name.ldap.attribute": ["cn"],
+                "group.object.classes": ["groupOfNames"],
+                "preserve.group.inheritance": ["false"],
+                "membership.ldap.attribute": ["member"],
+                "membership.attribute.type": ["DN"],
+                "membership.user.ldap.attribute": ["uid"],
+                "groups.ldap.filter": [""],
+                "mode": ["READ_ONLY"],
+                "user.roles.retrieve.strategy": ["LOAD_GROUPS_BY_MEMBER_ATTRIBUTE"],
+                "mapped.group.attributes": [""],
+                "drop.non.existing.groups.during.sync": ["false"]
+              }
+            }
+          ]
+        }
       }
     ]
   }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,32 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=reports_cdn:10m max_size=1g inactive=60m use_temp_path=off;
+
+    # Эмулирует edge-узел CDN перед S3-совместимым объектным хранилищем
+    # (MinIO). Объекты отчётов адресуются непредсказуемым ключом на каждый
+    # отчёт (см. reports-api/app/s3_client.py), поэтому их безопасно кэшировать
+    # и отдавать здесь без повторной проверки авторизации на каждый запрос -
+    # новый прогон Airflow даёт новый ключ, что естественным образом
+    # инвалидирует кэш.
+    server {
+        listen 8080;
+
+        location /reports/ {
+            proxy_pass http://minio:9000/reports/;
+            proxy_cache reports_cdn;
+            proxy_cache_valid 200 60m;
+            proxy_cache_key $uri;
+            proxy_cache_use_stale error timeout updating;
+            add_header X-Cache-Status $upstream_cache_status always;
+        }
+
+        location / {
+            return 404;
+        }
+    }
+}

--- a/reports-api/Dockerfile
+++ b/reports-api/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/reports-api/app/auth.py
+++ b/reports-api/app/auth.py
@@ -1,0 +1,37 @@
+import jwt
+from fastapi import Header, HTTPException
+from jwt import PyJWKClient
+
+from .config import settings
+
+_jwks_client = PyJWKClient(settings.jwks_url)
+
+
+def get_current_username(authorization: str = Header(default=None)) -> str:
+    """Проверяет bearer access_token и возвращает имя аутентифицированного пользователя.
+
+    Подпись, audience, issuer и срок действия проверяются по опубликованным
+    ключам Keycloak - reports-api никогда не доверяет идентичности,
+    переданной вызывающей стороной.
+    """
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing bearer token")
+
+    token = authorization.removeprefix("Bearer ").strip()
+
+    try:
+        signing_key = _jwks_client.get_signing_key_from_jwt(token)
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256"],
+            audience=settings.expected_audience,
+            issuer=settings.expected_issuer,
+        )
+    except jwt.PyJWTError as exc:
+        raise HTTPException(status_code=401, detail=f"Invalid token: {exc}")
+
+    username = claims.get("preferred_username")
+    if not username:
+        raise HTTPException(status_code=401, detail="Token missing preferred_username claim")
+    return username

--- a/reports-api/app/clickhouse_client.py
+++ b/reports-api/app/clickhouse_client.py
@@ -1,0 +1,40 @@
+from typing import Optional
+
+import clickhouse_connect
+
+from .config import settings
+
+_client = clickhouse_connect.get_client(
+    host=settings.clickhouse_host,
+    port=settings.clickhouse_port,
+    username=settings.clickhouse_user,
+    password=settings.clickhouse_password,
+)
+
+_COLUMNS = [
+    "customer_id", "report_generated_at", "full_name", "region",
+    "prosthesis_model", "events_count", "avg_myosignal_quality",
+    "avg_recognition_latency_ms", "min_battery_level", "last_action_recognized",
+]
+
+
+def get_latest_report(customer_id: str) -> Optional[dict]:
+    """Читает последнюю строку отчёта, обработанную ETL, для клиента.
+
+    Всегда читает только предварительно агрегированную витрину - никогда не
+    обращается к исходным базам CRM/телеметрии и не вычисляет агрегаты на лету.
+    """
+    query = f"""
+        SELECT {", ".join(_COLUMNS)}
+        FROM reports.user_report_mart_v2
+        WHERE customer_id = {{customer_id:String}}
+        ORDER BY report_generated_at DESC
+        LIMIT 1
+    """
+    result = _client.query(query, parameters={"customer_id": customer_id})
+    if not result.result_rows:
+        return None
+    row = result.result_rows[0]
+    report = dict(zip(_COLUMNS, row))
+    report["report_generated_at"] = report["report_generated_at"].isoformat()
+    return report

--- a/reports-api/app/config.py
+++ b/reports-api/app/config.py
@@ -1,0 +1,37 @@
+import os
+
+
+class Settings:
+    keycloak_internal_url: str = os.environ.get("KEYCLOAK_INTERNAL_URL", "http://keycloak:8080")
+    keycloak_realm: str = os.environ.get("KEYCLOAK_REALM", "reports-realm")
+    expected_audience: str = os.environ.get("EXPECTED_AUDIENCE", "reports-api")
+    expected_issuer: str = os.environ.get(
+        "EXPECTED_ISSUER", "https://localhost:8443/realms/reports-realm"
+    )
+
+    clickhouse_host: str = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
+    clickhouse_port: int = int(os.environ.get("CLICKHOUSE_PORT", "8123"))
+    clickhouse_user: str = os.environ.get("CLICKHOUSE_USER", "reports")
+    clickhouse_password: str = os.environ.get("CLICKHOUSE_PASSWORD", "reports_password")
+
+    s3_endpoint_url: str = os.environ.get("S3_ENDPOINT_URL", "http://minio:9000")
+    s3_access_key: str = os.environ.get("S3_ACCESS_KEY", "minio_user")
+    s3_secret_key: str = os.environ.get("S3_SECRET_KEY", "minio_password")
+    s3_bucket: str = os.environ.get("S3_BUCKET", "reports")
+    # Базовый URL, по которому браузер обращается к кэширующему reverse proxy
+    # (Nginx), стоящему перед MinIO и эмулирующему CDN.
+    cdn_base_url: str = os.environ.get("CDN_BASE_URL", "http://localhost:8090")
+    # HMAC-ключ для вывода непредсказуемых ключей/ссылок объектов на отчёты.
+    report_link_secret: str = os.environ.get(
+        "REPORT_LINK_SECRET", "dev-report-link-secret-change-in-production"
+    )
+
+    redis_url: str = os.environ.get("REDIS_URL", "redis://redis:6379/1")
+    pointer_cache_ttl_seconds: int = int(os.environ.get("POINTER_CACHE_TTL_SECONDS", "300"))
+
+    @property
+    def jwks_url(self) -> str:
+        return f"{self.keycloak_internal_url}/realms/{self.keycloak_realm}/protocol/openid-connect/certs"
+
+
+settings = Settings()

--- a/reports-api/app/main.py
+++ b/reports-api/app/main.py
@@ -1,0 +1,56 @@
+from fastapi import Depends, FastAPI, HTTPException
+
+from .auth import get_current_username
+from .clickhouse_client import get_latest_report
+from .redis_cache import get_cached_pointer, set_cached_pointer
+from .s3_client import ensure_bucket, get_cached_report_url, object_key_for, store_report
+
+app = FastAPI(title="reports-api")
+
+
+@app.on_event("startup")
+async def startup():
+    ensure_bucket()
+
+
+@app.get("/reports")
+async def get_my_report(username: str = Depends(get_current_username)):
+    # customer_id всегда берётся из проверенного токена, а не из параметра,
+    # переданного клиентом, поэтому пользователь может получить доступ
+    # только к собственному отчёту.
+
+    # 1. Указатель в Redis: полностью пропускает ClickHouse при повторных
+    #    запросах в пределах TTL - именно это убирает повторную нагрузку
+    #    на OLAP, о которой идёт речь в задании.
+    pointer = get_cached_pointer(username)
+    if pointer:
+        cached_url = get_cached_report_url(pointer["object_key"])
+        if cached_url:
+            return {"url": cached_url, "cached": True}
+
+    # 2. Указателя нет/истёк, либо объект пропал из S3: ищем последний
+    #    обработанный ETL отчёт (дешёвый точечный запрос по индексу,
+    #    никогда не вычисление агрегатов на лету).
+    report = get_latest_report(username)
+    if report is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No report has been generated for the current processed period yet",
+        )
+
+    object_key = object_key_for(username, report["report_generated_at"])
+    set_cached_pointer(username, report["report_generated_at"], object_key)
+
+    # 3. Кэш объекта в S3/CDN: перегенерируем JSON только если его ещё нет
+    #    в объектном хранилище для этого конкретного обработанного периода.
+    cached_url = get_cached_report_url(object_key)
+    if cached_url:
+        return {"url": cached_url, "cached": True}
+
+    url = store_report(object_key, report)
+    return {"url": url, "cached": False}
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/reports-api/app/redis_cache.py
+++ b/reports-api/app/redis_cache.py
@@ -1,0 +1,28 @@
+import json
+from typing import Optional
+
+import redis
+
+from .config import settings
+
+_redis = redis.from_url(settings.redis_url, decode_responses=True)
+
+_PREFIX = "reports-api:latest:"
+
+
+def get_cached_pointer(customer_id: str) -> Optional[dict]:
+    """Короткоживущий указатель на последние известные report_generated_at/object_key
+    для клиента. Позволяет повторным запросам полностью пропускать ClickHouse - TTL
+    (короче часового цикла ETL) ограничивает, сколько времени запрос может идти
+    без повторной проверки на наличие более свежего обработанного отчёта.
+    """
+    raw = _redis.get(_PREFIX + customer_id)
+    return json.loads(raw) if raw else None
+
+
+def set_cached_pointer(customer_id: str, report_generated_at: str, object_key: str) -> None:
+    _redis.set(
+        _PREFIX + customer_id,
+        json.dumps({"report_generated_at": report_generated_at, "object_key": object_key}),
+        ex=settings.pointer_cache_ttl_seconds,
+    )

--- a/reports-api/app/s3_client.py
+++ b/reports-api/app/s3_client.py
@@ -1,0 +1,74 @@
+import hashlib
+import hmac
+import json
+
+import boto3
+from botocore.client import Config
+from botocore.exceptions import ClientError
+
+from .config import settings
+
+_s3 = boto3.client(
+    "s3",
+    endpoint_url=settings.s3_endpoint_url,
+    aws_access_key_id=settings.s3_access_key,
+    aws_secret_access_key=settings.s3_secret_key,
+    config=Config(signature_version="s3v4"),
+    region_name="us-east-1",
+)
+
+_BUCKET = settings.s3_bucket
+
+
+def ensure_bucket():
+    try:
+        _s3.head_bucket(Bucket=_BUCKET)
+    except ClientError:
+        _s3.create_bucket(Bucket=_BUCKET)
+        # Объекты адресуются непредсказуемым токеном на каждый отчёт (см.
+        # object_key_for ниже), поэтому анонимный GET по точному ключу
+        # безопасен - именно это позволяет Nginx/CDN отдавать закэшированные
+        # отчёты без повторной проверки авторизации на каждый запрос.
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": f"arn:aws:s3:::{_BUCKET}/reports/*",
+            }],
+        }
+        _s3.put_bucket_policy(Bucket=_BUCKET, Policy=json.dumps(policy))
+
+
+def object_key_for(customer_id: str, report_generated_at: str) -> str:
+    """Детерминированный, непредсказуемый ключ объекта для одного обработанного отчёта.
+
+    Ключ строится из (customer_id, report_generated_at): новый прогон Airflow -
+    меняющий report_generated_at - естественным образом даёт новый ключ, поэтому
+    кэш CDN инвалидируется неявно, без ручной очистки.
+    """
+    digest = hmac.new(
+        settings.report_link_secret.encode("utf-8"),
+        f"{customer_id}:{report_generated_at}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"reports/{digest}.json"
+
+
+def get_cached_report_url(object_key: str) -> str | None:
+    try:
+        _s3.head_object(Bucket=_BUCKET, Key=object_key)
+    except ClientError:
+        return None
+    return f"{settings.cdn_base_url}/{_BUCKET}/{object_key}"
+
+
+def store_report(object_key: str, report: dict) -> str:
+    _s3.put_object(
+        Bucket=_BUCKET,
+        Key=object_key,
+        Body=json.dumps(report).encode("utf-8"),
+        ContentType="application/json",
+    )
+    return f"{settings.cdn_base_url}/{_BUCKET}/{object_key}"

--- a/reports-api/requirements.txt
+++ b/reports-api/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+pyjwt[crypto]==2.9.0
+clickhouse-connect==0.8.3
+boto3==1.35.24
+redis==5.0.8

--- a/telemetry/init/01_schema.sql
+++ b/telemetry/init/01_schema.sql
@@ -1,0 +1,28 @@
+-- Замена контейнера "База данных" (PostgreSQL) с исходной C4-диаграммы:
+-- сырая техническая телеметрия, отправляемая чипом протеза (качество
+-- миосигнала, задержка распознавания, уровень заряда батареи).
+CREATE TABLE telemetry_events (
+    event_id            BIGSERIAL PRIMARY KEY,
+    customer_id         VARCHAR(64) NOT NULL,
+    device_id           VARCHAR(64) NOT NULL,
+    event_ts            TIMESTAMP NOT NULL,
+    myosignal_quality   NUMERIC(5, 2) NOT NULL,  -- 0..100
+    recognition_latency_ms INTEGER NOT NULL,
+    battery_level       INTEGER NOT NULL,        -- 0..100
+    action_recognized   VARCHAR(64) NOT NULL
+);
+
+CREATE INDEX idx_telemetry_customer_ts ON telemetry_events (customer_id, event_ts);
+
+INSERT INTO telemetry_events (customer_id, device_id, event_ts, myosignal_quality, recognition_latency_ms, battery_level, action_recognized) VALUES
+    ('user1', 'dev-001', now() - interval '2 hours', 92.5, 78, 64, 'grip'),
+    ('user1', 'dev-001', now() - interval '1 hours', 90.1, 82, 63, 'release'),
+    ('user2', 'dev-002', now() - interval '3 hours', 88.4, 95, 41, 'pinch'),
+    ('user2', 'dev-002', now() - interval '2 hours', 87.9, 99, 40, 'grip'),
+    ('prothetic1', 'dev-003', now() - interval '5 hours', 95.2, 60, 77, 'grip'),
+    ('prothetic1', 'dev-003', now() - interval '4 hours', 94.8, 63, 76, 'release'),
+    ('prothetic2', 'dev-004', now() - interval '6 hours', 81.0, 110, 55, 'step'),
+    ('prothetic2', 'dev-004', now() - interval '5 hours', 83.4, 105, 54, 'step'),
+    ('prothetic3', 'dev-005', now() - interval '1 hours', 96.6, 55, 88, 'grip'),
+    ('john.doe', 'dev-006', now() - interval '2 hours', 89.9, 84, 70, 'grip'),
+    ('jane.smith', 'dev-007', now() - interval '3 hours', 91.4, 74, 66, 'step');


### PR DESCRIPTION
…ез S3/CDN, CDC из CRM

Задание 1. Повышение безопасности системы
- Заменена схема OAuth2 Code Grant на Authorization Code + PKCE (S256)
- Новый бэкенд-сервис bionicpro-auth (Python, FastAPI): серверный обмен access/refresh токенов с Keycloak, хранение токенов в Redis (refresh - в зашифрованном виде), сессионная HttpOnly+Secure cookie, автообновление access_token по refresh_token, ротация session id на каждом запросе к защищённому ресурсу
- Фронтенд переведён на работу через сессионную cookie, прямая интеграция с Keycloak (keycloak-js) удалена
- Keycloak: access_token TTL 120s, refresh token rotation, обязательный OTP для всех пользователей, LDAP User Federation с маппингом ролей, Identity Provider Yandex ID (generic OAuth2 broker, claim-маппинг под ответ Яндекса)
- Экспортирован realm в keycloak/keycloak-results-export.json
- Диаграмма архитектуры безопасности (architecture/task1-security-c4.drawio.xml)

Задание 2. Разработка сервиса отчётов
- Диаграмма архитектуры сервиса отчётов (architecture/task2-reports-c4.drawio.xml)
- Airflow DAG (airflow/dags/reports_etl_dag.py): почасовое построение витрины в ClickHouse из CRM и телеметрии; параметры подключения к БД берутся из Airflow Variables, а не хардкодятся в коде DAG
- Бэкенд reports-api (Python, FastAPI): GET /reports проверяет Bearer-токен (JWKS Keycloak) и отдаёт готовый отчёт по customer_id из токена - без вычислений в реальном времени и без доступа к чужим отчётам
- В UI добавлена кнопка получения отчёта

Задание 3. Снижение нагрузки на базу данных
- Redis-указатель на последний обработанный отчёт, чтобы повторные запросы не обращались к ClickHouse
- Кэш готовых отчётов в MinIO (S3 API) с непредсказуемым ключом объекта, который автоматически инвалидируется новым прогоном Airflow
- Nginx как reverse proxy с кэшированием, эмулирующий CDN перед MinIO

Задание 4. Повышение оперативности и стабильности CRM
- Debezium (Kafka Connect) отслеживает изменения таблицы customers в CRM и публикует их в топик Kafka
- ClickHouse читает топик через движок Kafka и MaterializedView строит актуальное измерение клиентов без массовых выгрузок из CRM
- Итоговая витрина объединяет CDC-данные CRM и агрегаты телеметрии через MaterializedView; reports-api переведён на эту витрину